### PR TITLE
Update jsonnet-libs and use Grafana v7.0 features

### DIFF
--- a/production/sample/default/main.jsonnet
+++ b/production/sample/default/main.jsonnet
@@ -2,7 +2,11 @@ local prometheus = import 'prometheus-ksonnet/prometheus-ksonnet.libsonnet';
 local promtail = import 'promtail/promtail.libsonnet';
 local tns_mixin = import 'tns-mixin/mixin.libsonnet';
 
-prometheus + promtail + tns_mixin + {
+prometheus + promtail + {
+  // A known data source UID is necessary to configure the Loki datasource such that users can pivot
+  // from Loki logs to Jaeger traces on traceID.
+  local jaeger_data_source_uid = 'jaeger',
+  local jaeger_query_url = 'http://jaeger.jaeger.svc.cluster.local:16686/jaeger/',
   local service = $.core.v1.service,
   _config+:: {
     namespace: 'default',
@@ -42,10 +46,6 @@ prometheus + promtail + tns_mixin + {
         },
       ],
     },
-  },
-
-  _images+:: {
-    grafana: 'grafana/grafana:6.6.1',
   },
 
   nginx_service+:
@@ -104,4 +104,7 @@ prometheus + promtail + tns_mixin + {
           )
         ])
       ,
+  mixins+:: {
+    tns_demo: tns_mixin,
+  },
 }

--- a/production/sample/jsonnetfile.json
+++ b/production/sample/jsonnetfile.json
@@ -1,7 +1,43 @@
 {
+  "version": 1,
   "dependencies": [
     {
-      "name": "jaeger",
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "ksonnet-util"
+        }
+      },
+      "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "prometheus-ksonnet"
+        }
+      },
+      "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/loki.git",
+          "subdir": "production/ksonnet/promtail"
+        }
+      },
+      "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/ksonnet/ksonnet-lib.git",
+          "subdir": "ksonnet.beta.4"
+        }
+      },
+      "version": "master"
+    },
+    {
       "source": {
         "local": {
           "directory": "../production/jaeger"
@@ -10,27 +46,6 @@
       "version": ""
     },
     {
-      "name": "ksonnet-util",
-      "source": {
-        "git": {
-          "remote": "https://github.com/grafana/jsonnet-libs",
-          "subdir": "ksonnet-util"
-        }
-      },
-      "version": "master"
-    },
-    {
-      "name": "ksonnet.beta.4",
-      "source": {
-        "git": {
-          "remote": "https://github.com/ksonnet/ksonnet-lib",
-          "subdir": "ksonnet.beta.4"
-        }
-      },
-      "version": "master"
-    },
-    {
-      "name": "loki",
       "source": {
         "local": {
           "directory": "../production/loki"
@@ -39,27 +54,6 @@
       "version": ""
     },
     {
-      "name": "prometheus-ksonnet",
-      "source": {
-        "git": {
-          "remote": "https://github.com/grafana/jsonnet-libs",
-          "subdir": "prometheus-ksonnet"
-        }
-      },
-      "version": "master"
-    },
-    {
-      "name": "promtail",
-      "source": {
-        "git": {
-          "remote": "https://github.com/grafana/loki",
-          "subdir": "production/ksonnet/promtail"
-        }
-      },
-      "version": "master"
-    },
-    {
-      "name": "tns",
       "source": {
         "local": {
           "directory": "../production/tns"
@@ -68,7 +62,6 @@
       "version": ""
     },
     {
-      "name": "tns-mixin",
       "source": {
         "local": {
           "directory": "../production/tns-mixin"
@@ -76,5 +69,6 @@
       },
       "version": ""
     }
-  ]
+  ],
+  "legacyImports": true
 }

--- a/production/sample/jsonnetfile.lock.json
+++ b/production/sample/jsonnetfile.lock.json
@@ -1,32 +1,10 @@
 {
+  "version": 1,
   "dependencies": [
     {
-      "name": "alertmanager-mixin",
       "source": {
         "git": {
-          "remote": "https://github.com/prometheus/alertmanager",
-          "subdir": "doc/alertmanager-mixin"
-        }
-      },
-      "version": "2c193c84e80fdd34f37f539c7d5c97e0d7f2f50c",
-      "sum": "1l51RtpwfcfGlHeBYBWsD8BpOmZyb05eu2EbpVJkrMQ="
-    },
-    {
-      "name": "grafana-builder",
-      "source": {
-        "git": {
-          "remote": "https://github.com/kausalco/public",
-          "subdir": "grafana-builder"
-        }
-      },
-      "version": "7ac7da1a0fe165b68cdb718b2521b560d51bd1f4",
-      "sum": "slxrtftVDiTlQK22ertdfrg4Epnq97gdrLI63ftUfaE="
-    },
-    {
-      "name": "grafonnet",
-      "source": {
-        "git": {
-          "remote": "https://github.com/grafana/grafonnet-lib",
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
           "subdir": "grafonnet"
         }
       },
@@ -34,7 +12,127 @@
       "sum": "CeM3LRgUCUJTolTdMnerfMPGYmhClx7gX5ajrQVEY2Y="
     },
     {
-      "name": "jaeger",
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "grafana-builder"
+        }
+      },
+      "version": "30d86dde82e47a4bd0d2c63d30a858847b89e19f",
+      "sum": "N65Fv0M2JvFE3GN8ZxP5xh1U5a314ey8geLAioJLzF8="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "ksonnet-util"
+        }
+      },
+      "version": "7ac7da1a0fe165b68cdb718b2521b560d51bd1f4",
+      "sum": "LKsTTBcH8TXX5ANgRUu5I7Y1tf5le4nANFV3/W53I+c="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "oauth2-proxy"
+        }
+      },
+      "version": "7ac7da1a0fe165b68cdb718b2521b560d51bd1f4",
+      "sum": "njaEcgj39Cau1InalHnw3MEufWp9Rmrg7bO4RH1LTCA=",
+      "name": "oauth2_proxy"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "prometheus-ksonnet"
+        }
+      },
+      "version": "30d86dde82e47a4bd0d2c63d30a858847b89e19f",
+      "sum": "00S11GPcmXmCHGyygD8QmeizqisYMArXkBfv7plP/8g="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/loki.git",
+          "subdir": "production/ksonnet/promtail"
+        }
+      },
+      "version": "7682b32cbae8c1146d44601ebf4b13cc9c718b98",
+      "sum": "MOoAhHzLkR7NSqD7ZVqjlcSDNRUz3fVgJQiYM1hd+us="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/kausalco/public.git",
+          "subdir": "grafana-builder"
+        }
+      },
+      "version": "7ac7da1a0fe165b68cdb718b2521b560d51bd1f4",
+      "sum": "slxrtftVDiTlQK22ertdfrg4Epnq97gdrLI63ftUfaE="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/ksonnet/ksonnet-lib.git",
+          "subdir": "ksonnet.beta.4"
+        }
+      },
+      "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f",
+      "sum": "ur22hPQq0JAPBxm8hNMcwjumj4MkozDwOKiGZvVMYh4="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/kubernetes-monitoring/kubernetes-mixin.git",
+          "subdir": ""
+        }
+      },
+      "version": "0ee0da08a9691201a118d30f6b396381c2c8d017",
+      "sum": "r+ibLhIoXzEWGXUCntSd44IRxeopnZkFfZ0OGZR2s1U="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/kubernetes-monitoring/kubernetes-mixin.git",
+          "subdir": "lib/promgrafonnet"
+        }
+      },
+      "version": "92309e9c7a7637c38a12c0964e62a7aeccaf49ae",
+      "sum": "VhgBM39yv0f4bKv8VfGg4FXkg573evGDRalip9ypKbc="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/prometheus/alertmanager.git",
+          "subdir": "doc/alertmanager-mixin"
+        }
+      },
+      "version": "2c193c84e80fdd34f37f539c7d5c97e0d7f2f50c",
+      "sum": "1l51RtpwfcfGlHeBYBWsD8BpOmZyb05eu2EbpVJkrMQ="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/prometheus/node_exporter.git",
+          "subdir": "docs/node-mixin"
+        }
+      },
+      "version": "eac3e30f7f7f564c2bd110c7bb97390711e45e32",
+      "sum": "7vEamDTP9AApeiF4Zu9ZyXzDIs3rYHzwf9k7g8X+wsg="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/prometheus/prometheus.git",
+          "subdir": "documentation/prometheus-mixin"
+        }
+      },
+      "version": "641676b3975c72241041047323de178136491eb0",
+      "sum": "u1YS9CVuBTcw2vks0PZbLb1gtlI/7bVGDVBZsjWFLTw="
+    },
+    {
       "source": {
         "local": {
           "directory": "../production/jaeger"
@@ -43,40 +141,6 @@
       "version": ""
     },
     {
-      "name": "ksonnet-util",
-      "source": {
-        "git": {
-          "remote": "https://github.com/grafana/jsonnet-libs",
-          "subdir": "ksonnet-util"
-        }
-      },
-      "version": "7ac7da1a0fe165b68cdb718b2521b560d51bd1f4",
-      "sum": "LKsTTBcH8TXX5ANgRUu5I7Y1tf5le4nANFV3/W53I+c="
-    },
-    {
-      "name": "ksonnet.beta.4",
-      "source": {
-        "git": {
-          "remote": "https://github.com/ksonnet/ksonnet-lib",
-          "subdir": "ksonnet.beta.4"
-        }
-      },
-      "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f",
-      "sum": "ur22hPQq0JAPBxm8hNMcwjumj4MkozDwOKiGZvVMYh4="
-    },
-    {
-      "name": "kubernetes-mixin",
-      "source": {
-        "git": {
-          "remote": "https://github.com/kubernetes-monitoring/kubernetes-mixin",
-          "subdir": ""
-        }
-      },
-      "version": "0ee0da08a9691201a118d30f6b396381c2c8d017",
-      "sum": "r+ibLhIoXzEWGXUCntSd44IRxeopnZkFfZ0OGZR2s1U="
-    },
-    {
-      "name": "loki",
       "source": {
         "local": {
           "directory": "../production/loki"
@@ -85,73 +149,6 @@
       "version": ""
     },
     {
-      "name": "node-mixin",
-      "source": {
-        "git": {
-          "remote": "https://github.com/prometheus/node_exporter",
-          "subdir": "docs/node-mixin"
-        }
-      },
-      "version": "eac3e30f7f7f564c2bd110c7bb97390711e45e32",
-      "sum": "7vEamDTP9AApeiF4Zu9ZyXzDIs3rYHzwf9k7g8X+wsg="
-    },
-    {
-      "name": "oauth2_proxy",
-      "source": {
-        "git": {
-          "remote": "https://github.com/grafana/jsonnet-libs",
-          "subdir": "oauth2-proxy"
-        }
-      },
-      "version": "7ac7da1a0fe165b68cdb718b2521b560d51bd1f4",
-      "sum": "njaEcgj39Cau1InalHnw3MEufWp9Rmrg7bO4RH1LTCA="
-    },
-    {
-      "name": "prometheus-ksonnet",
-      "source": {
-        "git": {
-          "remote": "https://github.com/grafana/jsonnet-libs",
-          "subdir": "prometheus-ksonnet"
-        }
-      },
-      "version": "7ac7da1a0fe165b68cdb718b2521b560d51bd1f4",
-      "sum": "wH4ZLwFq9/zl2EOZ9mAXf2yqGOvhR44h6BF4KpvM8VY="
-    },
-    {
-      "name": "prometheus-mixin",
-      "source": {
-        "git": {
-          "remote": "https://github.com/prometheus/prometheus",
-          "subdir": "documentation/prometheus-mixin"
-        }
-      },
-      "version": "641676b3975c72241041047323de178136491eb0",
-      "sum": "u1YS9CVuBTcw2vks0PZbLb1gtlI/7bVGDVBZsjWFLTw="
-    },
-    {
-      "name": "promgrafonnet",
-      "source": {
-        "git": {
-          "remote": "https://github.com/kubernetes-monitoring/kubernetes-mixin",
-          "subdir": "lib/promgrafonnet"
-        }
-      },
-      "version": "92309e9c7a7637c38a12c0964e62a7aeccaf49ae",
-      "sum": "VhgBM39yv0f4bKv8VfGg4FXkg573evGDRalip9ypKbc="
-    },
-    {
-      "name": "promtail",
-      "source": {
-        "git": {
-          "remote": "https://github.com/grafana/loki",
-          "subdir": "production/ksonnet/promtail"
-        }
-      },
-      "version": "cb798635f5e7241f36517ae89ce764c13729f130",
-      "sum": "tIrxV9SermVKhtftRuK7fmcJMv/9Hthk2jqeBkwz6/M="
-    },
-    {
-      "name": "tns",
       "source": {
         "local": {
           "directory": "../production/tns"
@@ -160,7 +157,6 @@
       "version": ""
     },
     {
-      "name": "tns-mixin",
       "source": {
         "local": {
           "directory": "../production/tns-mixin"
@@ -168,5 +164,6 @@
       },
       "version": ""
     }
-  ]
+  ],
+  "legacyImports": false
 }

--- a/production/tns-mixin/dashboards.libsonnet
+++ b/production/tns-mixin/dashboards.libsonnet
@@ -18,6 +18,7 @@ local g = (import 'grafana-builder/grafana.libsonnet') + {
 };
 
 {
+  grafanaDashboardFolder: 'TNS',
   grafanaDashboards+: {
     'demo-red.json':
       g.dashboard('Demo App')


### PR DESCRIPTION
- Also configure Loki data source to user internal Jaeger trace viewer

@buro9 for visibility.

I've manually tested the changes in this PR from a clean cluster and I personally think the internal trace view provides a nice refinement to the TNS story.