### PR TITLE
Use internal tracing view

### DIFF
--- a/production/sample/default/main.jsonnet
+++ b/production/sample/default/main.jsonnet
@@ -13,7 +13,7 @@ prometheus + promtail + {
     cluster_name: 'docker',
     admin_services+: [
       { title: 'TNS Demo', path: 'tns-demo', url: 'http://app.tns.svc.cluster.local/', subfilter: true },
-      { title: 'Jaeger', path: 'jaeger', url: 'http://jaeger.jaeger.svc.cluster.local:16686/jaeger/' },
+      { title: 'Jaeger', path: 'jaeger', url: jaeger_query_url },
     ],
     promtail_config+: {
       clients: [{
@@ -74,7 +74,7 @@ prometheus + promtail + {
               derivedFields: [{
                 matcherRegex: 'traceID=(\\w+)',
                 name: 'TraceID',
-                url: '/jaeger/trace/$${__value.raw}',
+                url: '../jaeger/trace/$${__value.raw}',
               }],
             },
           },
@@ -82,7 +82,7 @@ prometheus + promtail + {
             name: 'Jaeger',
             type: 'jaeger',
             access: 'browser',
-            url: 'http://jaeger.jaeger.svc.cluster.local:16686',
+            url: jaeger_query_url,
             isDefault: false,
             version: 1,
             editable: false,

--- a/production/sample/default/main.jsonnet
+++ b/production/sample/default/main.jsonnet
@@ -72,9 +72,10 @@ prometheus + promtail + {
             jsonData: {
               maxLines: 1000,
               derivedFields: [{
-                matcherRegex: 'traceID=(\\w+)',
+                matcherRegex: '(?:traceID|trace_id)=(\\w+)',
                 name: 'TraceID',
-                url: '../jaeger/trace/$${__value.raw}',
+                url: '$${__value.raw}',
+                datasourceUid: jaeger_data_source_uid,
               }],
             },
           },
@@ -82,6 +83,7 @@ prometheus + promtail + {
             name: 'Jaeger',
             type: 'jaeger',
             access: 'browser',
+            uid: jaeger_data_source_uid,
             url: jaeger_query_url,
             isDefault: false,
             version: 1,


### PR DESCRIPTION
This PR has tow changes:

- It corrects the URL for jaeger, which was not configured correctly in the datasource
- It switches to the new Grafana 7 tracing view within Grafana
