### PR TITLE
Make loki compatible with new jsonnet lib

### DIFF
--- a/production/loki/loki-app.libsonnet
+++ b/production/loki/loki-app.libsonnet
@@ -32,7 +32,7 @@
   ,
 
   loki_statefulset: statefulset.new('loki', 1, loki_container, [$.loki_pvc])
-                    .withVolumes([
+                    + statefulset.mixin.spec.template.spec.withVolumes([
                       volume.fromPersistentVolumeClaim('loki-data', 'loki-data'),
                       volume.fromSecret('loki-config', 'loki-config'),
                     ])


### PR DESCRIPTION
This small change makes the loki lib compatible with both ksonnet lib and k8salpha.