### PR TITLE
Make TNS compose the "complete" demo:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 */.uptodate
 /tanka
 .volume
+production/tns-mixin/jsonnetfile.lock.json

--- a/production/docker-compose/Makefile
+++ b/production/docker-compose/Makefile
@@ -1,0 +1,4 @@
+build-mixin:
+	pushd ../tns-mixin && jb install && popd
+	mkdir -p dashboards
+	mixtool generate dashboards -d ./dashboards ../tns-mixin/mixin.libsonnet

--- a/production/docker-compose/README.md
+++ b/production/docker-compose/README.md
@@ -13,3 +13,12 @@ $ docker-compose up -d
 The navigate to http://localhost:3000 to see Grafana.
 
 If you have any problems, run `docker-compose up -d` first.
+
+Optionally, [enable docker metrics](https://docs.docker.com/config/daemon/prometheus/) by adding this to your docker config:
+
+```json
+{
+  "metrics-addr" : "127.0.0.1:9323",
+  "experimental" : true
+}
+```

--- a/production/docker-compose/dashboards.yaml
+++ b/production/docker-compose/dashboards.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+- name: 'dashboards'
+  orgId: 1
+  folder: ''
+  type: 'file'
+  disableDeletion: true
+  editable: false
+  options:
+    path: '/etc/grafana/dashboards'

--- a/production/docker-compose/dashboards/demo-red.json
+++ b/production/docker-compose/dashboards/demo-red.json
@@ -1,0 +1,640 @@
+{
+      "annotations": {
+         "list": [ ]
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "links": [ ],
+      "refresh": "10s",
+      "rows": [
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+               {
+                  "aliasColors": {
+                     "200": "#7EB26D",
+                     "500": "#E24D42"
+                  },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 10,
+                  "id": 1,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 0,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 6,
+                  "stack": true,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "sum by (status_code) (rate(tns_request_duration_seconds_count{job=~\"$namespace/loadgen\"}[1m]))",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{status_code}}",
+                        "refId": "A",
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "QPS",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 1,
+                  "id": 2,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 6,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "histogram_quantile(0.99, sum(rate(tns_request_duration_seconds_bucket{job=~\"$namespace/loadgen\"}[$__rate_interval])) by (le)) * 1e3",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "99th Percentile",
+                        "refId": "A",
+                        "step": 10
+                     },
+                     {
+                        "expr": "histogram_quantile(0.50, sum(rate(tns_request_duration_seconds_bucket{job=~\"$namespace/loadgen\"}[$__rate_interval])) by (le)) * 1e3",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "50th Percentile",
+                        "refId": "B",
+                        "step": 10
+                     },
+                     {
+                        "expr": "sum(rate(tns_request_duration_seconds_sum{job=~\"$namespace/loadgen\"}[$__rate_interval])) * 1e3 / sum(rate(tns_request_duration_seconds_count{job=~\"$namespace/loadgen\"}[$__rate_interval]))",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "Average",
+                        "refId": "C",
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Latency",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "ms",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Load balancer",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+               {
+                  "aliasColors": {
+                     "200": "#7EB26D",
+                     "500": "#E24D42"
+                  },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 10,
+                  "id": 3,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 0,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 6,
+                  "stack": true,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "sum by (status_code) (rate(tns_request_duration_seconds_count{job=~\"$namespace/app\"}[1m]))",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{status_code}}",
+                        "refId": "A",
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "QPS",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 1,
+                  "id": 4,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 6,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "histogram_quantile(0.99, sum(rate(tns_request_duration_seconds_bucket{job=~\"$namespace/app\"}[$__rate_interval])) by (le)) * 1e3",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "99th Percentile",
+                        "refId": "A",
+                        "step": 10
+                     },
+                     {
+                        "expr": "histogram_quantile(0.50, sum(rate(tns_request_duration_seconds_bucket{job=~\"$namespace/app\"}[$__rate_interval])) by (le)) * 1e3",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "50th Percentile",
+                        "refId": "B",
+                        "step": 10
+                     },
+                     {
+                        "expr": "sum(rate(tns_request_duration_seconds_sum{job=~\"$namespace/app\"}[$__rate_interval])) * 1e3 / sum(rate(tns_request_duration_seconds_count{job=~\"$namespace/app\"}[$__rate_interval]))",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "Average",
+                        "refId": "C",
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Latency",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "ms",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "App",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+               {
+                  "aliasColors": {
+                     "200": "#7EB26D",
+                     "500": "#E24D42"
+                  },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 10,
+                  "id": 5,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 0,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 6,
+                  "stack": true,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "sum by (status_code) (rate(tns_request_duration_seconds_count{job=~\"$namespace/db\"}[1m]))",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{status_code}}",
+                        "refId": "A",
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "QPS",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 1,
+                  "id": 6,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 6,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "histogram_quantile(0.99, sum(rate(tns_request_duration_seconds_bucket{job=~\"$namespace/db\"}[$__rate_interval])) by (le)) * 1e3",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "99th Percentile",
+                        "refId": "A",
+                        "step": 10
+                     },
+                     {
+                        "expr": "histogram_quantile(0.50, sum(rate(tns_request_duration_seconds_bucket{job=~\"$namespace/db\"}[$__rate_interval])) by (le)) * 1e3",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "50th Percentile",
+                        "refId": "B",
+                        "step": 10
+                     },
+                     {
+                        "expr": "sum(rate(tns_request_duration_seconds_sum{job=~\"$namespace/db\"}[$__rate_interval])) * 1e3 / sum(rate(tns_request_duration_seconds_count{job=~\"$namespace/db\"}[$__rate_interval]))",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "Average",
+                        "refId": "C",
+                        "step": 10
+                     }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Latency",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "ms",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "DB",
+            "titleSize": "h6"
+         }
+      ],
+      "schemaVersion": 14,
+      "style": "dark",
+      "tags": [ ],
+      "templating": {
+         "list": [
+            {
+               "current": {
+                  "text": "default",
+                  "value": "default"
+               },
+               "hide": 0,
+               "label": null,
+               "name": "datasource",
+               "options": [ ],
+               "query": "prometheus",
+               "refresh": 1,
+               "regex": "",
+               "type": "datasource"
+            },
+            {
+               "allValue": ".+",
+               "current": {
+                  "selected": true,
+                  "text": "All",
+                  "value": "$__all"
+               },
+               "datasource": "$datasource",
+               "hide": 0,
+               "includeAll": true,
+               "label": "namespace",
+               "multi": true,
+               "name": "namespace",
+               "options": [ ],
+               "query": "label_values(kube_pod_container_info{image=~\".*grafana/tns.*\"}, namespace)",
+               "refresh": 1,
+               "regex": "",
+               "sort": 2,
+               "tagValuesQuery": "",
+               "tags": [ ],
+               "tagsQuery": "",
+               "type": "query",
+               "useTags": false
+            }
+         ]
+      },
+      "time": {
+         "from": "now-1h",
+         "to": "now"
+      },
+      "timepicker": {
+         "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+         ],
+         "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+         ]
+      },
+      "timezone": "utc",
+      "title": "Demo App",
+      "uid": "",
+      "version": 0
+   }

--- a/production/docker-compose/datasources.yaml
+++ b/production/docker-compose/datasources.yaml
@@ -15,6 +15,7 @@ datasources:
         datasourceUid: tempo
   - name: Loki
     type: loki
+    uid: loki
     access: proxy
     orgId: 1
     url: http://loki:3100
@@ -37,5 +38,8 @@ datasources:
     editable: false
     isDefault: false
     jsonData:
-        httpMethod: GET
+      httpMethod: GET
+      tracesToLogs:
+        datasourceUid: 'loki'
+        tags: ['job', 'instance']
     version: 1

--- a/production/docker-compose/docker-compose.yml
+++ b/production/docker-compose/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - 0.0.0.0:8000:80
     environment:
       JAEGER_ENDPOINT: 'http://tempo:14268/api/traces'
-      JAEGER_TAGS: cluster=tns,namespace=tns
+      JAEGER_TAGS: job=db
       JAEGER_SAMPLER_TYPE: const
       JAEGER_SAMPLER_PARAM: 1
     logging: *default-logging
@@ -37,7 +37,7 @@ services:
       - 0.0.0.0:8001:80
     environment:
       JAEGER_ENDPOINT: 'http://tempo:14268/api/traces'
-      JAEGER_TAGS: cluster=tns,namespace=tns
+      JAEGER_TAGS: job=app
       JAEGER_SAMPLER_TYPE: const
       JAEGER_SAMPLER_PARAM: 1
     logging: *default-logging
@@ -53,7 +53,7 @@ services:
       - 0.0.0.0:8002:80
     environment:
       JAEGER_ENDPOINT: 'http://tempo:14268/api/traces'
-      JAEGER_TAGS: cluster=tns,namespace=tns
+      JAEGER_TAGS: job=loadgen
       JAEGER_SAMPLER_TYPE: const
       JAEGER_SAMPLER_PARAM: 1
     logging: *default-logging
@@ -67,7 +67,7 @@ services:
      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
      - GF_AUTH_DISABLE_LOGIN_FORM=true
     ports:
-     - "3000:3000"
+     - 0.0.0.0:3000:3000
     logging: *default-logging
 
   prometheus:
@@ -86,8 +86,33 @@ services:
       - db
       - loadgen
     ports:
-      - 0.0.0.0:8003:9090
+      - 0.0.0.0:9090:9090
     logging: *default-logging
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.38.7
+    container_name: cadvisor
+    ports:
+      - 8080:8080
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:rw
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    logging: *default-logging
+
+  node_exporter:
+    image: prom/node-exporter:v1.1.0
+    container_name: node_exporter
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)'
 
   loki:
     image: grafana/loki:2.1.0

--- a/production/docker-compose/docker-compose.yml
+++ b/production/docker-compose/docker-compose.yml
@@ -2,6 +2,7 @@ x-logging: &default-logging
   driver: loki
   options:
     loki-url: 'http://localhost:3100/api/prom/push'
+    labels: namespace
     loki-relabel-config: |
       - action: replace
         source_labels: ["namespace","compose_service"]
@@ -22,7 +23,7 @@ services:
       - 0.0.0.0:8000:80
     environment:
       JAEGER_ENDPOINT: 'http://tempo:14268/api/traces'
-      JAEGER_TAGS: job=db
+      JAEGER_TAGS: job=tns/db
       JAEGER_SAMPLER_TYPE: const
       JAEGER_SAMPLER_PARAM: 1
     labels:
@@ -40,7 +41,7 @@ services:
       - 0.0.0.0:8001:80
     environment:
       JAEGER_ENDPOINT: 'http://tempo:14268/api/traces'
-      JAEGER_TAGS: job=app
+      JAEGER_TAGS: job=tns/app
       JAEGER_SAMPLER_TYPE: const
       JAEGER_SAMPLER_PARAM: 1
     labels:
@@ -58,7 +59,7 @@ services:
       - 0.0.0.0:8002:80
     environment:
       JAEGER_ENDPOINT: 'http://tempo:14268/api/traces'
-      JAEGER_TAGS: job=loadgen
+      JAEGER_TAGS: job=tns/loadgen
       JAEGER_SAMPLER_TYPE: const
       JAEGER_SAMPLER_PARAM: 1
     labels:

--- a/production/docker-compose/docker-compose.yml
+++ b/production/docker-compose/docker-compose.yml
@@ -2,6 +2,13 @@ x-logging: &default-logging
   driver: loki
   options:
     loki-url: 'http://localhost:3100/api/prom/push'
+    loki-relabel-config: |
+      - action: replace
+        source_labels: ["compose_service"]
+        target_label: job
+      - action: replace
+        source_labels: ["container_name"]
+        target_label: instance
 
 version: '3.3'
 services:
@@ -67,10 +74,11 @@ services:
     image: tomwilkie/prometheus:0ea72b6a6
     user: root
     command:
-      - "--config.file=/etc/prometheus/prometheus.yml"
-      - "--storage.tsdb.path=/prometheus"
-      - "--enable-feature=exemplar-storage"
-      - "--log.level=debug"
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=1d
+      - --enable-feature=exemplar-storage
+      - --log.level=debug
     volumes:
       - ./prometheus.yaml:/etc/prometheus/prometheus.yml
     links:
@@ -83,14 +91,22 @@ services:
 
   loki:
     image: grafana/loki:2.1.0
-    command: -config.file=/etc/loki/local-config.yaml
+    command:
+      - -config.file=/etc/loki/local-config.yaml
+      - -table-manager.retention-period=1d
+      - -table-manager.retention-deletes-enabled=true
     ports:
-        - "3100:3100"
+      - "3100:3100"
     logging: *default-logging
 
   tempo:
     image: grafana/tempo:0.5.0
-    command: ["--target=all", "--storage.trace.backend=local", "--storage.trace.local.path=/var/tempo", "--auth.enabled=false"]
+    command:
+      - --target=all
+      - --storage.trace.backend=local
+      - --storage.trace.local.path=/var/tempo
+      - --auth.enabled=false
+      - --compactor.compaction.block-retention=24h
     ports:
       - "8004:80"
     logging: *default-logging

--- a/production/docker-compose/docker-compose.yml
+++ b/production/docker-compose/docker-compose.yml
@@ -4,7 +4,8 @@ x-logging: &default-logging
     loki-url: 'http://localhost:3100/api/prom/push'
     loki-relabel-config: |
       - action: replace
-        source_labels: ["compose_service"]
+        source_labels: ["namespace","compose_service"]
+        separator: "/"
         target_label: job
       - action: replace
         source_labels: ["container_name"]
@@ -24,6 +25,8 @@ services:
       JAEGER_TAGS: job=db
       JAEGER_SAMPLER_TYPE: const
       JAEGER_SAMPLER_PARAM: 1
+    labels:
+      namespace: tns
     logging: *default-logging
 
   app:
@@ -40,6 +43,8 @@ services:
       JAEGER_TAGS: job=app
       JAEGER_SAMPLER_TYPE: const
       JAEGER_SAMPLER_PARAM: 1
+    labels:
+      namespace: tns
     logging: *default-logging
 
   loadgen:
@@ -56,18 +61,24 @@ services:
       JAEGER_TAGS: job=loadgen
       JAEGER_SAMPLER_TYPE: const
       JAEGER_SAMPLER_PARAM: 1
+    labels:
+      namespace: tns
     logging: *default-logging
 
   grafana:
     image: grafana/grafana:7.4.x-exemplars
     volumes:
       - ./datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+      - ./dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml
+      - ./dashboards:/etc/grafana/dashboards
     environment:
      - GF_AUTH_ANONYMOUS_ENABLED=true
      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
      - GF_AUTH_DISABLE_LOGIN_FORM=true
     ports:
      - 0.0.0.0:3000:3000
+    labels:
+      namespace: monitoring
     logging: *default-logging
 
   prometheus:
@@ -79,6 +90,7 @@ services:
       - --storage.tsdb.retention.time=1d
       - --enable-feature=exemplar-storage
       - --log.level=debug
+      - --web.enable-admin-api
     volumes:
       - ./prometheus.yaml:/etc/prometheus/prometheus.yml
     links:
@@ -87,6 +99,8 @@ services:
       - loadgen
     ports:
       - 0.0.0.0:9090:9090
+    labels:
+      namespace: monitoring
     logging: *default-logging
 
   cadvisor:
@@ -99,6 +113,8 @@ services:
       - /var/run:/var/run:rw
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
+    labels:
+      namespace: monitoring
     logging: *default-logging
 
   node_exporter:
@@ -113,6 +129,9 @@ services:
       - '--path.rootfs=/rootfs'
       - '--path.sysfs=/host/sys'
       - '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)'
+    labels:
+      namespace: monitoring
+    logging: *default-logging
 
   loki:
     image: grafana/loki:2.1.0
@@ -122,6 +141,8 @@ services:
       - -table-manager.retention-deletes-enabled=true
     ports:
       - "3100:3100"
+    labels:
+      namespace: monitoring
     logging: *default-logging
 
   tempo:
@@ -134,6 +155,8 @@ services:
       - --compactor.compaction.block-retention=24h
     ports:
       - "8004:80"
+    labels:
+      namespace: monitoring
     logging: *default-logging
 
   tempo-query:
@@ -142,4 +165,6 @@ services:
       - BACKEND=tempo
     ports:
       - "8006:16686"
+    labels:
+      namespace: monitoring
     logging: *default-logging

--- a/production/docker-compose/prometheus.yaml
+++ b/production/docker-compose/prometheus.yaml
@@ -20,9 +20,18 @@ rule_files:
 # Here it's Prometheus itself.
 scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'grafana'
+    static_configs:
+    - targets: ['grafana:3000']
   - job_name: 'prometheus'
     static_configs:
     - targets: ['localhost:9090']
+  - job_name: 'loki'
+    static_configs:
+    - targets: ['loki:3100']
+  - job_name: 'tempo'
+    static_configs:
+    - targets: ['tempo:80']
   - job_name: 'app'
     static_configs:
     - targets: ['app:80']
@@ -32,6 +41,3 @@ scrape_configs:
   - job_name: 'loadgen'
     static_configs:
     - targets: ['loadgen:80']
-  - job_name: 'tempo'
-    static_configs:
-    - targets: ['tempo:14268']

--- a/production/docker-compose/prometheus.yaml
+++ b/production/docker-compose/prometheus.yaml
@@ -41,3 +41,12 @@ scrape_configs:
   - job_name: 'loadgen'
     static_configs:
     - targets: ['loadgen:80']
+  - job_name: 'docker'
+    static_configs:
+    - targets: ['docker.for.mac.host.internal:9323']
+  - job_name: 'node_exporter'
+    static_configs:
+    - targets: ['node_exporter:9100']
+  - job_name: 'cadvisor'
+    static_configs:
+    - targets: ['cadvisor:8080']

--- a/production/docker-compose/prometheus.yaml
+++ b/production/docker-compose/prometheus.yaml
@@ -20,33 +20,33 @@ rule_files:
 # Here it's Prometheus itself.
 scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-  - job_name: 'grafana'
+  - job_name: 'monitoring/grafana'
     static_configs:
     - targets: ['grafana:3000']
-  - job_name: 'prometheus'
+  - job_name: 'monitoring/prometheus'
     static_configs:
     - targets: ['localhost:9090']
-  - job_name: 'loki'
+  - job_name: 'monitoring/loki'
     static_configs:
     - targets: ['loki:3100']
-  - job_name: 'tempo'
+  - job_name: 'monitoring/tempo'
     static_configs:
     - targets: ['tempo:80']
-  - job_name: 'app'
+  - job_name: 'tns/app'
     static_configs:
     - targets: ['app:80']
-  - job_name: 'db'
+  - job_name: 'tns/db'
     static_configs:
     - targets: ['db:80']
-  - job_name: 'loadgen'
+  - job_name: 'tns/loadgen'
     static_configs:
     - targets: ['loadgen:80']
-  - job_name: 'docker'
+  - job_name: 'monitoring/docker'
     static_configs:
     - targets: ['docker.for.mac.host.internal:9323']
-  - job_name: 'node_exporter'
+  - job_name: 'monitoring/node_exporter'
     static_configs:
     - targets: ['node_exporter:9100']
-  - job_name: 'cadvisor'
+  - job_name: 'monitoring/cadvisor'
     static_configs:
     - targets: ['cadvisor:8080']

--- a/production/tns-mixin/dashboards.libsonnet
+++ b/production/tns-mixin/dashboards.libsonnet
@@ -27,33 +27,33 @@ local g = (import 'grafana-builder/grafana.libsonnet') + {
         g.row('Load balancer')
         .addPanel(
           g.panel('QPS') +
-          g.qpsSimplePanel('tns_request_duration_seconds_count{job="$namespace/loadgen"}')
+          g.qpsSimplePanel('tns_request_duration_seconds_count{job=~"$namespace/loadgen"}')
         )
         .addPanel(
           g.panel('Latency') +
-          g.latencyPanel('tns_request_duration_seconds', '{job="$namespace/loadgen"}')
+          g.latencyPanel('tns_request_duration_seconds', '{job=~"$namespace/loadgen"}')
         )
       )
       .addRow(
         g.row('App')
         .addPanel(
           g.panel('QPS') +
-          g.qpsSimplePanel('tns_request_duration_seconds_count{job="$namespace/app"}')
+          g.qpsSimplePanel('tns_request_duration_seconds_count{job=~"$namespace/app"}')
         )
         .addPanel(
           g.panel('Latency') +
-          g.latencyPanel('tns_request_duration_seconds', '{job="$namespace/app"}')
+          g.latencyPanel('tns_request_duration_seconds', '{job=~"$namespace/app"}')
         )
       )
       .addRow(
         g.row('DB')
         .addPanel(
           g.panel('QPS') +
-          g.qpsSimplePanel('tns_request_duration_seconds_count{job="$namespace/db"}')
+          g.qpsSimplePanel('tns_request_duration_seconds_count{job=~"$namespace/db"}')
         )
         .addPanel(
           g.panel('Latency') +
-          g.latencyPanel('tns_request_duration_seconds', '{job="$namespace/db"}')
+          g.latencyPanel('tns_request_duration_seconds', '{job=~"$namespace/db"}')
         )
       ),
   },

--- a/production/tns-mixin/jsonnetfile.json
+++ b/production/tns-mixin/jsonnetfile.json
@@ -1,14 +1,15 @@
 {
-    "dependencies": [
-        {
-            "name": "grafana-builder",
-            "source": {
-                "git": {
-                    "remote": "https://github.com/grafana/jsonnet-libs",
-                    "subdir": "grafana-builder"
-                }
-            },
-            "version": "master"
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "grafana-builder"
         }
-    ]
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
 }


### PR DESCRIPTION
- [x] Limit retention to 1d on all the service, so we don't run out of resources when left running
- [x] Setup Loki relabeling to match prometheus labels.
- [x] Setup tempo labels to match prometheus labels.
- [x] Investigate prometheus instance labels
- [x] Add node exporter
- [x] Add node mixin and tns mixin

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>