### PR TITLE
Build for arm64 when on a new Mac.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ publish: lint-image/.published
 
 IMAGE_TAG?=$(shell git rev-parse --short HEAD)
 DOCKER_IMAGE_BASE?=grafana
-GOENV=GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GO111MODULE=on
+GOENV=GOOS=linux GOARCH=$(shell go env GOARCH) CGO_ENABLED=0 GO111MODULE=on
 
 db/db: db/*.go
 	env $(GOENV) go build -o $@ ./db


### PR DESCRIPTION
Looks like everything else (loki, prometheus, tempo, grafana) is already built for arm64.