### PR TITLE
Use 15s scrape interval

### DIFF
--- a/production/sample/default/main.jsonnet
+++ b/production/sample/default/main.jsonnet
@@ -64,7 +64,7 @@ local tns_mixin = import 'tns-mixin/mixin.libsonnet';
       },
       metrics+: {
         global+: {
-          scrape_interval: '60s',
+          scrape_interval: '15s',
           external_labels: {
             cluster: 'tns',
           },


### PR DESCRIPTION
Dashboards use 1m resolution so 60s scrape interval will not work.

See #21

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>