### PR TITLE
Updated README to point to latest k3d release, added tips to doc section

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,12 @@ your docker daemon has at least 2.5 GB of total memory available for all pods in
 ### k3d
 To run this demo, you need a Kubernetes cluster. While the demo should work against any
 Kubernetes cluster, these docs will assume a locally running `k3d` cluster. Download and
-install `k3d` from [here](https://github.com/rancher/k3d/releases/tag/v3.2.0).
+install `k3d` from [here](https://github.com/rancher/k3d/releases/latest).
+
+Rename the binary to k3d and move it to a location in $PATH. Also make sure the binary is executable:
+```
+$ chmod +x /usr/local/bin/k3d
+```
 
 ### kubectl
 `kubectl` is used to interact with Kubernetes clusters. Follow the instructions


### PR DESCRIPTION
I went through the demo today and ran into an issue with k3d. The installation instructions for k3d point to an old release, v3.2.0. I installed that version and ran into trouble during cluster creation as one of the k3d command line flags had changed. Initially I thought it was a typo in the `create-k3d-cluster` script and made a change there, only to run into a more errors from k3d. After installing the latest version, v5.2.2, the `create-k3d-cluster` script worked without any changes and I could continue with the demo by following the README.

This makes 2 changes to the demo documentation:
- The link to k3d in the Prerequisites section now points to the latest version.
- I added a comment in the same section about renaming the downloaded file to `k3d` and setting execute permissions. This is similar to what is stated in the `jsonnet-bundler` section.