### PR TITLE
Change main.jsonnet to support current k8

### DIFF
--- a/production/sample/default/main.jsonnet
+++ b/production/sample/default/main.jsonnet
@@ -27,9 +27,9 @@ local tns_mixin = import 'tns-mixin/mixin.libsonnet';
   local container = k.core.v1.container,
   local containerPort = k.core.v1.containerPort,
   local envVar = k.core.v1.envVar,
-  local httpIngressPath = k.extensions.v1beta1.httpIngressPath,
-  local ingress = k.extensions.v1beta1.ingress,
-  local ingressRule = k.extensions.v1beta1.ingressRule,
+  local httpIngressPath = k.networking.v1.httpIngressPath,
+  local ingress = k.networking.v1.ingress,
+  local ingressRule = k.networking.v1.ingressRule,
   local service = k.core.v1.service,
 
   // Create a Grafana Agent daemon set to collect metrics, logs, and traces
@@ -205,7 +205,7 @@ local tns_mixin = import 'tns-mixin/mixin.libsonnet';
       }),
     }),
 
-  ingress: ingress.new() +
+  ingress: ingress.new('ingress') +
            ingress.mixin.metadata.withName('ingress')
            + ingress.mixin.metadata.withAnnotationsMixin({
              'ingress.kubernetes.io/ssl-redirect': 'false',
@@ -213,8 +213,9 @@ local tns_mixin = import 'tns-mixin/mixin.libsonnet';
            + ingress.mixin.spec.withRules([
              ingressRule.mixin.http.withPaths(
                httpIngressPath.withPath('/') +
-               httpIngressPath.backend.withServiceName('nginx') +
-               httpIngressPath.backend.withServicePort(80)
+               httpIngressPath.withPathType('ImplementationSpecific') +
+               httpIngressPath.backend.service.withName('nginx') +
+               httpIngressPath.backend.service.port.withNumber(80)
              ),
            ])
   ,


### PR DESCRIPTION
Disclaimer: this is my first time doing anything with kubernetes and there are probably implications here I'm not aware of but I got this working and wanted to show someone.

When going through the readme for this, I didn't install the specified releases and instead just ran the brew command. I think specifically this was an issue for `k3d`. It will surprise no one that not following the directions means the install didn't run successfully. Comparing notes on the `k8s-libsonnet` documentation got me to the following edits which do run successfully. 

If k8s/k3d has breaking changes often then I can see why the readme recommends specific versions to go along with this config. Feel free to close!