### PR TITLE
Fix compatibility with Kubernetes 1.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The TNS app is an example three-tier web app built by Weaveworks. It consists of
 The instrumentation for the TNS app is as follows:
 
 - Metrics: Each tier of the TNS app exposes metrics on /metrics endpoints, which are scraped by the Grafana Agent. Additionally, these metrics are additionally tagged with exemplar information. The Grafana Agent then writes these metrics to a Prometheus (with remote-read enabled) for storage. [While the Prometheus could scrape metrics from the TNS App directly, the demo is configured to make the Agent the central point through which metrics, logs, and traces are collected. The Prometheus can be substituted for any backend which accepts Prometheus remote write, such as Thanos or Cortex.]
-- Logs: Each tier of the TNS app writes logs to standard output or standard error which is captured by Kubernetes, which are then collected by the Grafana Agent, which forwards them on to Loki for storage.
+- Logs: Each tier of the TNS app writes logs to standard output or standard error. It is captured by Kubernetes, which are then collected by the Grafana Agent. Finally, the Agent forwards them to Loki for storage.
 
 - Traces: Each tier of the TNS app sends traces in Jaeger format to the Grafana Agent, which then converts them to OTel format and forwards them to Tempo for storage.
 Visualization: A Grafana instance configured to talk to the Prometheus, Loki, and Tempo instances makes it possible to query and visualize the metrics, logs, and traces data.
@@ -181,7 +181,7 @@ $ rm -rf tanka
 
 **Issue:** 404 error when trying to load Tempo traces.
 
-**Solution:** This is likely because the jaeger agent is not running correctly. Check that all pods were successfully scheduled.
+**Solution:** Your Jaeger agent is likely not running correctly. Check that all pods were successfully scheduled.
 
 ## Contributing guidelines
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ The TNS app is an example three-tier web app built by Weaveworks. It consists of
 The instrumentation for the TNS app is as follows:
 
 - Metrics: Each tier of the TNS app exposes metrics on /metrics endpoints, which are scraped by the Grafana Agent. Additionally, these metrics are additionally tagged with exemplar information. The Grafana Agent then writes these metrics to a Prometheus (with remote-read enabled) for storage. [While the Prometheus could scrape metrics from the TNS App directly, the demo is configured to make the Agent the central point through which metrics, logs, and traces are collected. The Prometheus can be substituted for any backend which accepts Prometheus remote write, such as Thanos or Cortex.]
-- Logs: Each tier of the TNS app writes logs to standard output or standard error which is captured by Kubernetes, which are then collected by the Grafana Agent, which forwards them on to Loki for storage. 
+- Logs: Each tier of the TNS app writes logs to standard output or standard error which is captured by Kubernetes, which are then collected by the Grafana Agent, which forwards them on to Loki for storage.
 
-- Traces: Each tier of the TNS app sends traces in Jaeger format to the Grafana Agent, which then converts them to OTel format and forwards them to Tempo for storage. 
-Visualization: A Grafana instance configured to talk to the Prometheus, Loki, and Tempo instances makes it possible to query and visualize the metrics, logs, and traces data. 
+- Traces: Each tier of the TNS app sends traces in Jaeger format to the Grafana Agent, which then converts them to OTel format and forwards them to Tempo for storage.
+Visualization: A Grafana instance configured to talk to the Prometheus, Loki, and Tempo instances makes it possible to query and visualize the metrics, logs, and traces data.
 
 
 ## Prerequisites
@@ -123,7 +123,7 @@ These instructions assume that you are using a local `k3d`. If you plan to use a
 
 1. Access TNS using the URL [http://localhost:8080/](http://localhost:8080).
 
-Note: If you need to re-do this process to get everything running, you can run `k3d cluster delete tns` to delete the cluster, then run `./create-k3d-cluster` and re-start the process. 
+Note: If you need to re-do this process to get everything running, you can run `k3d cluster delete tns` to delete the cluster, then run `./create-k3d-cluster` and re-start the process.
 
 ## Explore metrics to logs to traces
 
@@ -180,14 +180,8 @@ $ rm -rf tanka
 ## Troubleshooting
 
 **Issue:** 404 error when trying to load Tempo traces.
-   
+
 **Solution:** This is likely because the jaeger agent is not running correctly. Check that all pods were successfully scheduled.
-
-**Issue:** ./install.sh fails complaining about Ingress. You're using a `k3d` that runs a newer version of k8s. That means that Ingress got promoted and the `extensions.v1beta1.ingress` in [production/sample/default/main.jsonnet] is not valid anymore.
-
-**Solution:** You're using a newer version of `k3s`, which has a version of `k8s` that no longer supports Ingress under `extensions.v1beta1`. Verify you version by running `kubectl version`. As per [this blog post](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) k8s v1.22 and higher no longer serve that API.
-
-To resolve the issue, use an older version of `k3d` which will run an older version of `k8s`. For example, use version `k3d` 5.0.0 (runs `k8s` v1.21.5).
 
 ## Contributing guidelines
 
@@ -197,7 +191,7 @@ To resolve the issue, use an older version of `k3d` which will run an older vers
 - Instruct `k3d` to pull the new images on a pod restart (and not use the image from it's local cache): `k3d image import -c tns grafana/tns-app  && k3d image import -c tns grafana/tns-db &&  k3d image import -c tns grafana/tns-loadgen`.
 - Kill relevant pod(s) by running the following command: `kubectl delete pod app-69db48747b-s6qq6 --namespace=tns`.
 
-### Update Grafana dashboards and kubernetes infrastructure: 
+### Update Grafana dashboards and kubernetes infrastructure:
 
 - Update the manifests by running the following tanka command: `tk apply --force environments/<ENV>/main.jsonnet`.
 - Update Grafana, for example, when changing dashboards by running the following tanka command: `tk apply --force environments/default/main.jsonnet`.

--- a/install
+++ b/install
@@ -31,6 +31,9 @@ mkdir "$BASEDIR/tanka" && cd "$BASEDIR/tanka"
 # Initialise Tanka
 tk init --k8s=1.22
 
+# Workaround for https://github.com/jsonnet-libs/k8s/issues/132
+echo "(import 'github.com/jsonnet-libs/k8s-libsonnet/1.22/main.libsonnet') + { extensions:: null }" > lib/k.libsonnet
+
 # Copy dependency list into workdir
 ln -sf "$PROD"/jsonnetfile.json jsonnetfile.json
 ln -sf "$PROD"/jsonnetfile.lock.json jsonnetfile.lock.json
@@ -43,4 +46,3 @@ install_env loki    # Install loki logging app
 install_env tns     # Install TNS demo app
 install_env tempo   # Install tempo tracing app
 install_env default # Install default monitoring stack
-

--- a/install
+++ b/install
@@ -5,10 +5,11 @@ BASEDIR="$(cd "`dirname $0`"; pwd)"
 PROD="$BASEDIR/production/sample"
 
 function install_env {
+    echo "installing ${1}"
     ENV=$1
     tk env add environments/$ENV --server-from-context $CONTEXT --namespace $ENV # Creates/configures the environment.
     ln -sf "$PROD/$ENV/main.jsonnet" environments/$ENV/main.jsonnet # Copies the base configuration for your env.
-    tk apply environments/$ENV                                    # Installs everything for your environment.
+    tk apply environments/$ENV                                      # Installs everything for your environment.
 }
 
 if [[ $(docker info --format "{{.MemTotal}}") -lt 2560000000 ]]; then
@@ -25,14 +26,16 @@ if ! kubectl --context $CONTEXT get ns>/dev/null 2>&1; then
   exit 2
 fi
 
-# Initialise Tanka
 mkdir "$BASEDIR/tanka" && cd "$BASEDIR/tanka"
-tk init                  # Initialises Tanka, and downloads the Kubernetes libaries Tanka needs
-cp "$PROD"/jsonnetfile.* . # copies dependency list into current directory
-#fix deprication notice of k8s
-jb install github.com/jsonnet-libs/k8s-libsonnet/1.21@main
-echo "import 'github.com/jsonnet-libs/k8s-libsonnet/1.21/main.libsonnet'" > lib/k.libsonnet
-jb install               # Installs dependencies
+
+# Initialise Tanka
+tk init --k8s=1.22
+
+# Copy dependency list into workdir
+cp "$PROD"/jsonnetfile.* .
+
+# Install dependencies
+jb install
 
 # Install apps into separate namespaces
 install_env loki    # Install loki logging app

--- a/install
+++ b/install
@@ -32,7 +32,8 @@ mkdir "$BASEDIR/tanka" && cd "$BASEDIR/tanka"
 tk init --k8s=1.22
 
 # Copy dependency list into workdir
-cp "$PROD"/jsonnetfile.* .
+ln -sf "$PROD"/jsonnetfile.json jsonnetfile.json
+ln -sf "$PROD"/jsonnetfile.lock.json jsonnetfile.lock.json
 
 # Install dependencies
 jb install

--- a/production/sample/default/main.jsonnet
+++ b/production/sample/default/main.jsonnet
@@ -27,9 +27,9 @@ local tns_mixin = import 'tns-mixin/mixin.libsonnet';
   local container = k.core.v1.container,
   local containerPort = k.core.v1.containerPort,
   local envVar = k.core.v1.envVar,
-  local httpIngressPath = k.extensions.v1beta1.httpIngressPath,
-  local ingress = k.extensions.v1beta1.ingress,
-  local ingressRule = k.extensions.v1beta1.ingressRule,
+  local httpIngressPath = k.networking.v1.httpIngressPath,
+  local ingress = k.networking.v1.ingress,
+  local ingressRule = k.networking.v1.ingressRule,
   local service = k.core.v1.service,
 
   // Create a Grafana Agent daemon set to collect metrics, logs, and traces
@@ -205,16 +205,15 @@ local tns_mixin = import 'tns-mixin/mixin.libsonnet';
       }),
     }),
 
-  ingress: ingress.new() +
-           ingress.mixin.metadata.withName('ingress')
-           + ingress.mixin.metadata.withAnnotationsMixin({
+  ingress: ingress.new('ingress') +
+           ingress.mixin.metadata.withAnnotationsMixin({
              'ingress.kubernetes.io/ssl-redirect': 'false',
            })
            + ingress.mixin.spec.withRules([
              ingressRule.mixin.http.withPaths(
                httpIngressPath.withPath('/') +
-               httpIngressPath.backend.withServiceName('nginx') +
-               httpIngressPath.backend.withServicePort(80)
+               httpIngressPath.backend.service.withName('nginx') +
+               httpIngressPath.backend.service.port.withNumber(80)
              ),
            ])
   ,

--- a/production/sample/default/main.jsonnet
+++ b/production/sample/default/main.jsonnet
@@ -212,6 +212,7 @@ local tns_mixin = import 'tns-mixin/mixin.libsonnet';
            + ingress.mixin.spec.withRules([
              ingressRule.mixin.http.withPaths(
                httpIngressPath.withPath('/') +
+               httpIngressPath.withPathType('ImplementationSpecific') +
                httpIngressPath.backend.service.withName('nginx') +
                httpIngressPath.backend.service.port.withNumber(80)
              ),

--- a/production/sample/jsonnetfile.json
+++ b/production/sample/jsonnetfile.json
@@ -4,6 +4,15 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/grafana/agent.git",
+          "subdir": "production/tanka/grafana-agent"
+        }
+      },
+      "version": "main"
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/grafana/jsonnet-libs.git",
           "subdir": "ksonnet-util"
         }
@@ -32,16 +41,7 @@
       "source": {
         "git": {
           "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
-          "subdir": "1.20"
-        }
-      },
-      "version": "main"
-    },
-    {
-      "source": {
-        "git": {
-          "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
-          "subdir": "1.21"
+          "subdir": "1.22"
         }
       },
       "version": "main"
@@ -54,15 +54,6 @@
         }
       },
       "version": "master"
-    },
-    {
-      "source": {
-        "git": {
-          "remote": "https://github.com/grafana/agent.git",
-          "subdir": "production/tanka/grafana-agent"
-        }
-      },
-      "version": "main"
     },
     {
       "source": {

--- a/production/sample/jsonnetfile.lock.json
+++ b/production/sample/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "production/tanka/grafana-agent"
         }
       },
-      "version": "5bf8cf452fa76c75387e30b6373630923679221c",
-      "sum": "U7uF6KmVbuHINEHgpxcHChctDf3/ylh8ipnnXTfHanE="
+      "version": "55998adc6ddee290ff169107370cc5ad78ef9b9c",
+      "sum": "JGYJWrCvbt3FESTOVy5hv0mGDV2D4yzzmY/g54i312s="
     },
     {
       "source": {
@@ -18,8 +18,8 @@
           "subdir": "grafana-mixin"
         }
       },
-      "version": "fb05f253d4be0faa632d508fbe2254fb64b20493",
-      "sum": "ZI9dQSTtdDLwl8bGx1jy7xSs+5WJNxMGk6hudjoUNLA="
+      "version": "1120f9e255760a3c104b57871fcb91801e934382",
+      "sum": "MkjR7zCgq6MUZgjDzop574tFKoTX2OBr7DTwm1K+Ofs="
     },
     {
       "source": {
@@ -28,7 +28,7 @@
           "subdir": "grafonnet"
         }
       },
-      "version": "3626fc4dc2326931c530861ac5bebe39444f6cbf",
+      "version": "6db00c292d3a1c71661fc875f90e0ec7caa538c2",
       "sum": "gF8foHByYcB25jcUOBqP6jxk0OPifQMjPvKY0HaCk6w="
     },
     {
@@ -38,8 +38,8 @@
           "subdir": "alertmanager"
         }
       },
-      "version": "b102f9ac7d1290ac025c2a7ac99f7fd9a9948503",
-      "sum": "WkQf0/YlIixQ8IvFjojZR4k21vTsnygdYMBL/Tx+it0="
+      "version": "6ea03cde6ebe1860e84ae8f9fd4174196c97d6e4",
+      "sum": "qCez+icm27SCa0Q8aZZ/axDm/Tr+vTzpVXUBtIiWkgI="
     },
     {
       "source": {
@@ -48,8 +48,8 @@
           "subdir": "grafana"
         }
       },
-      "version": "b102f9ac7d1290ac025c2a7ac99f7fd9a9948503",
-      "sum": "BHvjNVA6foCySv2Rz6EY+miuwdGnsQxkqaOsZJYAi30="
+      "version": "6ea03cde6ebe1860e84ae8f9fd4174196c97d6e4",
+      "sum": "7rANfqY8ERvoABHbwoGsdGpUeHxxYCSVOcM4Eky4QtQ="
     },
     {
       "source": {
@@ -58,7 +58,7 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "b102f9ac7d1290ac025c2a7ac99f7fd9a9948503",
+      "version": "6ea03cde6ebe1860e84ae8f9fd4174196c97d6e4",
       "sum": "0KkygBQd/AFzUvVzezE4qF/uDYgrwUXVpZfINBti0oc="
     },
     {
@@ -68,8 +68,8 @@
           "subdir": "ksonnet-util"
         }
       },
-      "version": "b102f9ac7d1290ac025c2a7ac99f7fd9a9948503",
-      "sum": "fFVlCoa/N0qiqTbDhZAEdRm2Vv76Z9Clxp3/haJ+PyA="
+      "version": "6ea03cde6ebe1860e84ae8f9fd4174196c97d6e4",
+      "sum": "xo1A7iYvJ7OZ64q2dOZY0G8FGHHt+t/+vEJW3bnXHyk="
     },
     {
       "source": {
@@ -78,8 +78,8 @@
           "subdir": "kube-state-metrics"
         }
       },
-      "version": "b102f9ac7d1290ac025c2a7ac99f7fd9a9948503",
-      "sum": "kH7gD2rdqRtBujmCObN0ifNF/BkSZU8pleFRI8itkqY="
+      "version": "6ea03cde6ebe1860e84ae8f9fd4174196c97d6e4",
+      "sum": "YG6LxAQOAkOgqFYA+U7KMB1KTw2AXbrHelBTo8kXWBA="
     },
     {
       "source": {
@@ -88,8 +88,8 @@
           "subdir": "nginx-directory"
         }
       },
-      "version": "b102f9ac7d1290ac025c2a7ac99f7fd9a9948503",
-      "sum": "x6fKTfhS9BnBn4Vuir75j5pVd4W528NcFY5a/4IwNV4="
+      "version": "6ea03cde6ebe1860e84ae8f9fd4174196c97d6e4",
+      "sum": "KfO2SRsTE8Hx/ZP8GBDwRRm/jOHfzKMyRtdjQf2zYac="
     },
     {
       "source": {
@@ -98,8 +98,8 @@
           "subdir": "node-exporter"
         }
       },
-      "version": "b102f9ac7d1290ac025c2a7ac99f7fd9a9948503",
-      "sum": "vyQo9U1z9dLrnoEUY21L/3Ko03CGgHguaqjFPDhYC6Q="
+      "version": "6ea03cde6ebe1860e84ae8f9fd4174196c97d6e4",
+      "sum": "NrtW3s48yfeG97d6ULNSb1AzbslsRcf1olUsdwNt3JM="
     },
     {
       "source": {
@@ -108,8 +108,8 @@
           "subdir": "oauth2-proxy"
         }
       },
-      "version": "b102f9ac7d1290ac025c2a7ac99f7fd9a9948503",
-      "sum": "jP3iaFUZy6Q50CGNBOpITdnub6+dqxAt2iBiOaJpSVk="
+      "version": "6ea03cde6ebe1860e84ae8f9fd4174196c97d6e4",
+      "sum": "e4coY8Ht3lDdqfcrjHyFG1pAWbHdoJs5+hXTW/nLOVo="
     },
     {
       "source": {
@@ -118,8 +118,8 @@
           "subdir": "prometheus"
         }
       },
-      "version": "b102f9ac7d1290ac025c2a7ac99f7fd9a9948503",
-      "sum": "O+K/k3niBh+4P9C2gRPBk0iVwcHmriLiHjqotcxMYOM="
+      "version": "6ea03cde6ebe1860e84ae8f9fd4174196c97d6e4",
+      "sum": "m0X+B0CdfOZNufu+oZozv8oyoXrNSVtR52fI3DuqPQo="
     },
     {
       "source": {
@@ -128,8 +128,8 @@
           "subdir": "prometheus-ksonnet"
         }
       },
-      "version": "b102f9ac7d1290ac025c2a7ac99f7fd9a9948503",
-      "sum": "PgJTRnYEWUVnEGGlSArK9e94ednxI+IpWsRw22xmOxs="
+      "version": "6ea03cde6ebe1860e84ae8f9fd4174196c97d6e4",
+      "sum": "fQvRDXkWEi5F/sr9G52p1eVsuMiX3/fg/dSsCItLOog="
     },
     {
       "source": {
@@ -138,8 +138,8 @@
           "subdir": "production/ksonnet/promtail"
         }
       },
-      "version": "8ff27e243bac7a9ac6b9b9682be353ea545c3ec7",
-      "sum": "CX3OKhrk3DGpRnxTGvm7Uj6ZKrxjOYjnOg9kJyzs5aM="
+      "version": "f22dbc2190921e70d38e8b915aa64964879b6b78",
+      "sum": "d7azenENzcvtlgkTeDFWk2tL1QXPSiYRhrGc1Klroa8="
     },
     {
       "source": {
@@ -168,8 +168,8 @@
           "subdir": ""
         }
       },
-      "version": "9821d07e94e9a9916575a234fb699ae3331fa939",
-      "sum": "xubNXyvDwUw9GZzi9BRb6ob3bYzfoMr5F5zCVn2d7ag="
+      "version": "f2b5aab16039e7aa78c1b39aad1ec63d87eca85e",
+      "sum": "0x5qkZAgoM78WqZgmGFthmXREiDQUQYk5HYdjqOVgKs="
     },
     {
       "source": {
@@ -178,7 +178,7 @@
           "subdir": "lib/promgrafonnet"
         }
       },
-      "version": "9821d07e94e9a9916575a234fb699ae3331fa939",
+      "version": "f2b5aab16039e7aa78c1b39aad1ec63d87eca85e",
       "sum": "zv7hXGui6BfHzE9wPatHI/AGZa4A2WKo6pq7ZdqBsps="
     },
     {
@@ -188,8 +188,8 @@
           "subdir": "doc/alertmanager-mixin"
         }
       },
-      "version": "e2a10119aaf7777fa523d216e05897c5b719134c",
-      "sum": "pep+dHzfIjh2SU5pEkwilMCAT/NoL6YYflV4x8cr7vU="
+      "version": "71d61c9c9149420209c973014e0d6c981b183611",
+      "sum": "iqF63VWQovIGBb7JI5oVVgMShz0dKptSzEVQQjsy+Jo="
     },
     {
       "source": {
@@ -198,8 +198,8 @@
           "subdir": "docs/node-mixin"
         }
       },
-      "version": "b5cb72b4097f5782474efb37b66edace7a33cdb1",
-      "sum": "MlWDAKGZ+JArozRKdKEvewHeWn8j2DNBzesJfLVd0dk="
+      "version": "3d9ee5d9cc4545c7aaccc0f282f59478fe128ed1",
+      "sum": "fNanwWpnovE/ok6i7zlwd1mwOPbglp19edJdOLgTDnU="
     },
     {
       "source": {
@@ -208,8 +208,8 @@
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "bbbbe5b9df08016336bbb4b971b31d73b585ace3",
-      "sum": "ZjQoYhvgKwJNkg+h+m9lW3SYjnjv5Yx5btEipLhru88="
+      "version": "0b41fd6e716f3e8b79016f73b6dd77fdf5fcdced",
+      "sum": "APXOIP3B3dZ3Tyh7L2UhyWR8Vbf5+9adTLz/ya7n6uU="
     },
     {
       "source": {
@@ -218,8 +218,8 @@
           "subdir": ""
         }
       },
-      "version": "f6580d47a121aa383bfda8ad0fd64afb0bec1257",
-      "sum": "X/zxeRr6ZGVzvyiQ/2dTWvVQe0m3rwe2uRy12M7dSEs="
+      "version": "10f9abba16178bc1aa194d7474a0e53102768488",
+      "sum": "ev39xeqz2qTWu4FADh6W/xqpmfXFZEGXbdjqQbEz86o="
     },
     {
       "source": {

--- a/production/sample/jsonnetfile.lock.json
+++ b/production/sample/jsonnetfile.lock.json
@@ -145,21 +145,11 @@
       "source": {
         "git": {
           "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
-          "subdir": "1.20"
+          "subdir": "1.22"
         }
       },
-      "version": "efb8cd3f9e2a3562c24e10404d5ed8b6c2d67174",
-      "sum": "gyjizcAhl0s2EZZh+1tsRLe4a4TN3bjk33YptXnd6q8="
-    },
-    {
-      "source": {
-        "git": {
-          "remote": "https://github.com/jsonnet-libs/k8s-libsonnet.git",
-          "subdir": "1.21"
-        }
-      },
-      "version": "efb8cd3f9e2a3562c24e10404d5ed8b6c2d67174",
-      "sum": "EZpcgrWS8k6QCOMYW7t4wnLpCRlaikXLMDKJNV9ZD5Q="
+      "version": "3b2af2f1ef5c357a24069c104d5c26f10eb5f4a7",
+      "sum": "QRQoyFAjVnSvfq4UjA2vK/ueiGRhxxmVSAGRyGjLmtI="
     },
     {
       "source": {


### PR DESCRIPTION
fixes #35 

k8s 1.22 removed the beta endpoints for some resources, which caused the demo application to fail to install

This PR:
- adds k8s-libsonnet 1.22 (and removes 1.20 and 1.21)
- updates jsonnet libs using `jb update`
- updates `main.jsonnet` to use non-beta Ingress resources