### PR TITLE
Add cloud-specific deployment and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor
 /tanka
 .volume
 production/tns-mixin/jsonnetfile.lock.json
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ Visualization: A Grafana instance configured to talk to the Prometheus, Loki, an
 
 ## Prerequisites
 
-Before you begin, install and configure the following software applications.
+If you are running the full metrics, logs and traces stack locally, install and configure _all_ of the following software applications.
+
+If you wish to only deploy the TNS app to an existing K8s cluster using the `app-only` option, install and configure `kubectl`, `tanka`, and `jsonnet-bundler`.
 
 ### Docker
 
@@ -55,8 +57,7 @@ To run the TNS demo, you need a Kubernetes cluster. The cluster creation script 
 
 **Note:** Ensure that your Docker daemon has a minimum of 2.5 GB of total memory available for all pods in this deployment to be scheduled.
 
-You can also run the TNS demo without Kubernetes. Click [here](https://github.com/grafana/tns/blob/main/production/docker-compose/README.md).
- for more information.
+You can also run the TNS demo without Kubernetes. Click [here](https://github.com/grafana/tns/blob/main/production/docker-compose/README.md) for more information.
 
 ### kubectl
 
@@ -71,7 +72,7 @@ Tanka uses the Jsonnet language to interact with Kubernetes, via the `kubectl` t
 When you install the TNS demo application, it will create a `tanka` directory in your TNS checkout. This directory contains all of the Jsonnet resources used to install this demo.
 To find out more about Tanka, see https://tanka.dev.
 
-### Jsonnet-bundle
+### Jsonnet-bundler
 
 The Jsonnet bundler download Jsonnet dependencies. Click [here](https://github.com/jsonnet-bundler/jsonnet-bundler/releases/tag/v0.4.0) for download instructions.
 
@@ -83,7 +84,7 @@ After downloading the library:
     $ chmod +x /usr/local/bin/jb
     ```
 
-## Install TNS demo
+## Install TNS demo (running MLT stack locally)
 
 These instructions assume that you are using a local `k3d`. If you plan to use a Kubernetes cluster other than a local `k3d` one, you will need to modify these instructions for your setup.
 
@@ -124,6 +125,32 @@ These instructions assume that you are using a local `k3d`. If you plan to use a
 1. Access TNS using the URL [http://localhost:8080/](http://localhost:8080).
 
 Note: If you need to re-do this process to get everything running, you can run `k3d cluster delete tns` to delete the cluster, then run `./create-k3d-cluster` and re-start the process.
+
+## Install TNS demo app into an existing K8s cluster (`app-only` option)
+
+If you already have a K8s cluster *and* cloud metrics, logs, and traces services available to you, use the `app-only` option to deploy _only_ the instrumented TNS app to a Kubernetes cluster.
+
+A tutorial using this method will soon be available in Grafana Cloud's docs.
+
+1. Get Kubernetes context
+    ```sh
+    $ kubectl config get-contexts
+    ```
+    Note down the context you'd like to use to deploy the app.
+
+1. Deploy the app
+    ```sh
+    $ ./install CONTEXT_YOU_NOTED app-only
+    ```
+
+1. Confirm `yes` when prompted.
+
+1. Verify the status of your cluster by running this command.
+
+    ```sh
+    $ kubectl get pods -n tns-cloud
+    ```
+    If all the pods are listed as either `running`, your app is ready for use.
 
 ## Explore metrics to logs to traces
 

--- a/install
+++ b/install
@@ -13,7 +13,7 @@ function install_env {
     tk apply environments/$ENV                                      # Installs everything for your environment.
 }
 
-if [[ "$MODE" != "cloud" ]] && [[ $(docker info --format "{{.MemTotal}}") -lt 2560000000 ]]; then
+if [[ "$MODE" != "app-only" ]] && [[ $(docker info --format "{{.MemTotal}}") -lt 2560000000 ]]; then
   echo "WARNING: your docker daemon will likely need more memory in order to schedule all required pods"
 fi
 
@@ -43,7 +43,7 @@ ln -sf "$PROD"/jsonnetfile.lock.json jsonnetfile.lock.json
 jb install
 
 # Install apps into separate namespaces
-if [[ "$MODE" == "cloud" ]]; then 
+if [[ "$MODE" == "app-only" ]]; then
     install_env tns-cloud       # Only install (modified) TNS demo app into existing K8s cluster 
 else
     install_env loki            # Install loki logging app

--- a/install
+++ b/install
@@ -3,6 +3,7 @@
 CONTEXT=${1-k3d-tns}
 BASEDIR="$(cd "`dirname $0`"; pwd)"
 PROD="$BASEDIR/production/sample"
+MODE=${2-standard}
 
 function install_env {
     echo "installing ${1}"
@@ -12,7 +13,11 @@ function install_env {
     tk apply environments/$ENV                                      # Installs everything for your environment.
 }
 
-if [[ $(docker info --format "{{.MemTotal}}") -lt 2560000000 ]]; then
+function install_cloud {
+    install_env tns-cloud
+}
+
+if [[ "$MODE" != "cloud" ]] && [[ $(docker info --format "{{.MemTotal}}") -lt 2560000000 ]]; then
   echo "WARNING: your docker daemon will likely need more memory in order to schedule all required pods"
 fi
 
@@ -42,7 +47,11 @@ ln -sf "$PROD"/jsonnetfile.lock.json jsonnetfile.lock.json
 jb install
 
 # Install apps into separate namespaces
-install_env loki    # Install loki logging app
-install_env tns     # Install TNS demo app
-install_env tempo   # Install tempo tracing app
-install_env default # Install default monitoring stack
+if [[ "$MODE" != "cloud" ]]; then 
+    install_env loki    # Install loki logging app
+    install_env tns     # Install TNS demo app
+    install_env tempo   # Install tempo tracing app
+    install_env default # Install default monitoring stack
+else
+    install_cloud       # Only install (modified) TNS demo app into existing K8s cluster 
+fi

--- a/install
+++ b/install
@@ -13,10 +13,6 @@ function install_env {
     tk apply environments/$ENV                                      # Installs everything for your environment.
 }
 
-function install_cloud {
-    install_env tns-cloud
-}
-
 if [[ "$MODE" != "cloud" ]] && [[ $(docker info --format "{{.MemTotal}}") -lt 2560000000 ]]; then
   echo "WARNING: your docker daemon will likely need more memory in order to schedule all required pods"
 fi
@@ -47,11 +43,11 @@ ln -sf "$PROD"/jsonnetfile.lock.json jsonnetfile.lock.json
 jb install
 
 # Install apps into separate namespaces
-if [[ "$MODE" != "cloud" ]]; then 
-    install_env loki    # Install loki logging app
-    install_env tns     # Install TNS demo app
-    install_env tempo   # Install tempo tracing app
-    install_env default # Install default monitoring stack
+if [[ "$MODE" == "cloud" ]]; then 
+    install_env tns-cloud       # Only install (modified) TNS demo app into existing K8s cluster 
 else
-    install_cloud       # Only install (modified) TNS demo app into existing K8s cluster 
+    install_env loki            # Install loki logging app
+    install_env tns             # Install TNS demo app
+    install_env tempo           # Install tempo tracing app
+    install_env default         # Install default monitoring stack
 fi

--- a/production/sample/tns-cloud/main.jsonnet
+++ b/production/sample/tns-cloud/main.jsonnet
@@ -1,0 +1,13 @@
+local tns = import 'tns/tns.libsonnet';
+
+tns {
+  _config+:: {
+    namespace: 'tns-cloud',
+    tns+: {
+      jaeger+: {
+        host: 'grafana-agent-traces.default.svc.cluster.local',
+        tags: 'cluster=cloud,namespace=tns-cloud',
+      },
+    },
+  },
+}

--- a/production/tns-mixin/dashboards.libsonnet
+++ b/production/tns-mixin/dashboards.libsonnet
@@ -6,7 +6,7 @@ local g = (import 'grafana-builder/grafana.libsonnet') + {
     },
     targets: [
       {
-        expr: 'sum by (status_code) (rate(' + selector + '[1m]))',
+        expr: 'sum by (status_code) (rate(' + selector + '[$__rate_interval]))',
         format: 'time_series',
         intervalFactor: 2,
         legendFormat: '{{status_code}}',
@@ -131,7 +131,7 @@ local g = (import 'grafana-builder/grafana.libsonnet') + {
                 steppedLine: false,
                 targets: [
                   {
-                    expr: 'sum by (status_code) (rate(tns_request_duration_seconds_count{job=~"$namespace/loadgen"}[1m]))',
+                    expr: 'sum by (status_code) (rate(tns_request_duration_seconds_count{job=~"$namespace/loadgen"}[$__rate_interval]))',
                     format: 'time_series',
                     intervalFactor: 2,
                     legendFormat: '{{status_code}}',
@@ -322,7 +322,7 @@ local g = (import 'grafana-builder/grafana.libsonnet') + {
                 steppedLine: false,
                 targets: [
                   {
-                    expr: 'sum by (status_code) (rate(tns_request_duration_seconds_count{job=~"$namespace/app"}[1m]))',
+                    expr: 'sum by (status_code) (rate(tns_request_duration_seconds_count{job=~"$namespace/app"}[$__rate_interval]))',
                     format: 'time_series',
                     intervalFactor: 2,
                     legendFormat: '{{status_code}}',
@@ -513,7 +513,7 @@ local g = (import 'grafana-builder/grafana.libsonnet') + {
                 steppedLine: false,
                 targets: [
                   {
-                    expr: 'sum by (status_code) (rate(tns_request_duration_seconds_count{job=~"$namespace/db"}[1m]))',
+                    expr: 'sum by (status_code) (rate(tns_request_duration_seconds_count{job=~"$namespace/db"}[$__rate_interval]))',
                     format: 'time_series',
                     intervalFactor: 2,
                     legendFormat: '{{status_code}}',

--- a/production/tns-mixin/grr.jsonnet
+++ b/production/tns-mixin/grr.jsonnet
@@ -1,14 +1,14 @@
+local g = import 'grafana-builder/grafana.libsonnet';
 local grr = import 'grizzly/grizzly.libsonnet';
 local mixin = import 'mixin.libsonnet';
-local g = import 'grafana-builder/grafana.libsonnet';
 
 local templating = {
-  templating: g.dashboard('Demo App').addMultiTemplate('namespace', 'kube_namespace_status_phase{job="integrations/kubernetes/kube-state-metrics"}', 'namespace')['templating']
+  templating: g.dashboard('Demo App').addMultiTemplate('namespace', 'kube_namespace_status_phase{job="integrations/kubernetes/kube-state-metrics"}', 'namespace').templating,
 };
 
 local grrDashboards = [
   grr.dashboard.new(std.stripChars(fname, '.json'), mixin.grafanaDashboards[fname] + templating) +
-  grr.resource.addMetadata('folder', "TNS")
+  grr.resource.addMetadata('folder', 'TNS')
   for fname in std.objectFields(mixin.grafanaDashboards)
 ];
 

--- a/production/tns-mixin/grr.jsonnet
+++ b/production/tns-mixin/grr.jsonnet
@@ -1,0 +1,18 @@
+local grr = import 'grizzly/grizzly.libsonnet';
+local mixin = import 'mixin.libsonnet';
+local g = import 'grafana-builder/grafana.libsonnet';
+
+local templating = {
+  templating: g.dashboard('Demo App').addMultiTemplate('namespace', 'kube_namespace_status_phase{job="integrations/kubernetes/kube-state-metrics"}', 'namespace')['templating']
+};
+
+local grrDashboards = [
+  grr.dashboard.new(std.stripChars(fname, '.json'), mixin.grafanaDashboards[fname] + templating) +
+  grr.resource.addMetadata('folder', "TNS")
+  for fname in std.objectFields(mixin.grafanaDashboards)
+];
+
+{
+  folders: [grr.folder.new(mixin.grafanaDashboardFolder, mixin.grafanaDashboardFolder)],
+  dashboards: grrDashboards,
+}

--- a/production/tns-mixin/jsonnetfile.json
+++ b/production/tns-mixin/jsonnetfile.json
@@ -9,6 +9,15 @@
         }
       },
       "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "grizzly"
+        }
+      },
+      "version": "master"
     }
   ],
   "legacyImports": true


### PR DESCRIPTION
This PR makes it easier to deploy the TNS app and mixin when using our cloud products & [Kubernetes integration](https://grafana.com/docs/grafana-cloud/kubernetes/integration-kubernetes/). 

There will be an accompanying doc in [Cloud docs](https://grafana.com/docs/grafana-cloud/kubernetes/) that will walk the user through deploying the app, deploying the mixin (using Grizzly), and navigating the dashboards.

Existing code paths are mostly unchanged.

This PR does the following:
- When passing in an optional `cloud` parameter, installs _only_ the TNS app into an _existing_ K8s cluster, without Loki, Grafana, Agent, etc.
- When using the `cloud` deployment path, patches the app to use a slightly different Jaeger config (that is in line with the [default config & manifests](https://grafana.com/docs/grafana-cloud/kubernetes/agent-k8s/k8s_agent_traces/) we provide users)
- Modifies dashboards to use `rate_interval` everywhere [1]
- Adds a `grr.jsonnet` file to the TNS mixin to allow easy deployment to hosted Grafana instances using [Grizzly](https://github.com/grafana/grizzly)
- Patches the mixin to use a slightly different query for the `namespace` template variable, as our default K8s integration config drops this metric

[1] This is the only change that affects the non-`cloud` deployment path