### PR TITLE
Add Cloud K8s YAMLs

### DIFF
--- a/production/k8s-yamls-cloud/app-full.yaml
+++ b/production/k8s-yamls-cloud/app-full.yaml
@@ -1,0 +1,159 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tns-cloud
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: app
+  name: app
+  namespace: tns-cloud
+spec:
+  ports:
+  - name: app-http-metrics
+    port: 80
+    targetPort: 80
+  selector:
+    name: app
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: db
+  name: db
+  namespace: tns-cloud
+spec:
+  ports:
+  - name: db-http-metrics
+    port: 80
+    targetPort: 80
+  selector:
+    name: db
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: loadgen
+  name: loadgen
+  namespace: tns-cloud
+spec:
+  ports:
+  - name: loadgen-http-metrics
+    port: 80
+    targetPort: 80
+  selector:
+    name: loadgen
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  namespace: tns-cloud
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: app
+  template:
+    metadata:
+      labels:
+        name: app
+    spec:
+      containers:
+      - args:
+        - -log.level=debug
+        - http://db
+        env:
+        - name: JAEGER_AGENT_HOST
+          value: grafana-agent-traces.default.svc.cluster.local
+        - name: JAEGER_TAGS
+          value: cluster=cloud,namespace=tns-cloud
+        - name: JAEGER_SAMPLER_TYPE
+          value: const
+        - name: JAEGER_SAMPLER_PARAM
+          value: "1"
+        image: grafana/tns-app:latest
+        imagePullPolicy: IfNotPresent
+        name: app
+        ports:
+        - containerPort: 80
+          name: http-metrics
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: db
+  namespace: tns-cloud
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: db
+  template:
+    metadata:
+      labels:
+        name: db
+    spec:
+      containers:
+      - args:
+        - -log.level=debug
+        env:
+        - name: JAEGER_AGENT_HOST
+          value: grafana-agent-traces.default.svc.cluster.local
+        - name: JAEGER_TAGS
+          value: cluster=cloud,namespace=tns-cloud
+        - name: JAEGER_SAMPLER_TYPE
+          value: const
+        - name: JAEGER_SAMPLER_PARAM
+          value: "1"
+        image: grafana/tns-db:latest
+        imagePullPolicy: IfNotPresent
+        name: db
+        ports:
+        - containerPort: 80
+          name: http-metrics
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loadgen
+  namespace: tns-cloud
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: loadgen
+  template:
+    metadata:
+      labels:
+        name: loadgen
+    spec:
+      containers:
+      - args:
+        - -log.level=debug
+        - http://app
+        env:
+        - name: JAEGER_AGENT_HOST
+          value: grafana-agent-traces.default.svc.cluster.local
+        - name: JAEGER_TAGS
+          value: cluster=cloud,namespace=tns-cloud
+        - name: JAEGER_SAMPLER_TYPE
+          value: const
+        - name: JAEGER_SAMPLER_PARAM
+          value: "1"
+        image: grafana/tns-loadgen:latest
+        imagePullPolicy: IfNotPresent
+        name: loadgen
+        ports:
+        - containerPort: 80
+          name: http-metrics


### PR DESCRIPTION
This is to accompany a tutorial in Grafana Cloud docs and to circumvent the user having to clone the repo, run the install script with the `app-only` flag, install jsonnet & tanka, etc.

I noticed the other k8s-yamls dir seems unmaintained but keeping these separate for now. They are generated using the install script's `app-only` flag and configured to work out of the box with our Kubernetes integration & Agent quickstarts.  