### PR TITLE
Fix typo in news story title.

### DIFF
--- a/loadgen/stories.json
+++ b/loadgen/stories.json
@@ -21,7 +21,7 @@
             "url": "https://www.influxdata.com/blog/influxdata-secures-60-million-in-series-d-funding-to-bring-the-value-of-time-series-to-the-enterprise-mainstream/"
         },
         {
-            "title": "IBM aquires AWS, Google and Microsoft, still forth place in cloud.",
+            "title": "IBM acquires AWS, Google and Microsoft, still forth place in cloud.",
             "url": "https://www.zdnet.com/article/top-cloud-providers-2018-how-aws-microsoft-google-ibm-oracle-alibaba-stack-up/"
         },
         {


### PR DESCRIPTION
There's a small typo in the word `aquires` in one of the sample headlines.