### PR TITLE
Grafana 9.5 in docker-compose method

### DIFF
--- a/production/docker-compose/datasources.yaml
+++ b/production/docker-compose/datasources.yaml
@@ -7,12 +7,11 @@ datasources:
     editable: true
     isDefault: true
     jsonData:
-        httpMethod: GET
-    version: 1
-    jsonData:
+      httpMethod: GET
       exemplarTraceIdDestinations:
       - name: traceID
         datasourceUid: tempo
+    version: 1
   - name: Loki
     type: loki
     uid: loki

--- a/production/docker-compose/docker-compose.yml
+++ b/production/docker-compose/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     logging: *default-logging
 
   grafana:
-    image: grafana/grafana:8.2.2
+    image: grafana/grafana:9.5.3
     volumes:
       - ./datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
       - ./dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml


### PR DESCRIPTION
Just a few changes to make it run with Grafana 9 (with docker-compose method).
Everything seems to work fine: Datasources and dashboard are correctly loaded, correlation metrics > logs > traces works