### PR TITLE
jq assignment -> equality operator

### DIFF
--- a/install
+++ b/install
@@ -61,16 +61,16 @@ elif [[ "$MODE" == "grafana-cloud" ]]; then
   _config+:: {
     apiKey: '$APIKEY',
     prometheus+: {
-      endpoint: '$(jq -r --arg STACK $STACK '.items[] | select(.slug=$STACK) | .hmInstancePromUrl' $INSTANCESFILE)/api/prom/push',
-      user: $(jq --arg STACK $STACK '.items[] | select(.slug=$STACK) | .hmInstancePromId' $INSTANCESFILE),
+      endpoint: '$(jq -r --arg STACK $STACK '.items[] | select(.slug==$STACK) | .hmInstancePromUrl' $INSTANCESFILE)/api/prom/push',
+      user: $(jq --arg STACK $STACK '.items[] | select(.slug==$STACK) | .hmInstancePromId' $INSTANCESFILE),
     },
     loki+: {
-      endpoint: '$(jq -r --arg STACK $STACK '.items[] | select(.slug=$STACK) | .hlInstanceUrl' $INSTANCESFILE)/loki/api/v1/push',
-      user: $(jq --arg STACK $STACK '.items[] | select(.slug=$STACK) | .hlInstanceId' $INSTANCESFILE),
+      endpoint: '$(jq -r --arg STACK $STACK '.items[] | select(.slug==$STACK) | .hlInstanceUrl' $INSTANCESFILE)/loki/api/v1/push',
+      user: $(jq --arg STACK $STACK '.items[] | select(.slug==$STACK) | .hlInstanceId' $INSTANCESFILE),
     },
     tempo+: {
-      endpoint: '$(jq -r --arg STACK $STACK '.items[] | select(.slug=$STACK) | .htInstanceUrl' $INSTANCESFILE):443',
-      user: $(jq --arg STACK $STACK '.items[] | select(.slug=$STACK) | .htInstanceId' $INSTANCESFILE),
+      endpoint: '$(jq -r --arg STACK $STACK '.items[] | select(.slug==$STACK) | .htInstanceUrl' $INSTANCESFILE):443',
+      user: $(jq --arg STACK $STACK '.items[] | select(.slug==$STACK) | .htInstanceId' $INSTANCESFILE),
     },
   },
 }


### PR DESCRIPTION
Fixes the operator used with `jq`, to make sure the install script creates a valid JSON file, if there are multiple stacks in a Grafana Cloud org.

(with `=`, jq was returning all items, instead of just the stack we're interested in)

PTAL! Thank you :) 
