### PR TITLE
Enables exemplars and small README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ These instructions assume that you are using a local `k3d`. If you plan to use a
     $ ./install
     ```
 
-1. Confirm `yes` when prompted. You will be prompted four times during the installation.
+1. Confirm `yes` when prompted. You will be prompted five times during the installation.
 
     Wait for the installation to finish. It can take over ten minutes for everything to download and then start up.
 

--- a/production/mimir/configmap.libsonnet
+++ b/production/mimir/configmap.libsonnet
@@ -7,6 +7,7 @@
       http_listen_port: $._config.http.port,
       grpc_listen_port: $._config.grpc.port,
     },
+
     common: {
       storage: {
         filesystem: {
@@ -24,6 +25,9 @@
       tsdb: {
         dir: '%s/tsdb' % $._config.storage.path,
       },
+    },
+    limits: {
+      max_global_exemplars_per_user: 100000,
     },
   },
 


### PR DESCRIPTION
Fixes #50 by setting `max_global_exemplars_per_user` (which normally defaults to 0). Also, a small README fix for accuracy -- the user is prompted _five_ times (for `loki`, `tns`, `tempo`, `mimir`, and `default` namespaces).