### PR TITLE
Fail fast if install subcommands fail.

### DIFF
--- a/install
+++ b/install
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 CONTEXT=${1-k3d-tns}
 BASEDIR="$(cd "`dirname $0`"; pwd)"
 PROD="$BASEDIR/production/sample"


### PR DESCRIPTION
Use bash's `set -euo pipefail` to fail the entire script early if a subcommand fails. For me, I didn't have `tk` installed, so `./install` was chugging through hundreds of failing `tk` invocations.

To test this, I re-ran `./install` with and without `app-only` and it all seems to work correctly. (And it fails fast if `tk` is missing.)