### PR TITLE
Fix installer

### DIFF
--- a/install
+++ b/install
@@ -35,7 +35,7 @@ fi
 mkdir "$BASEDIR/tanka" && cd "$BASEDIR/tanka"
 
 # Initialise Tanka
-tk init --k8s=1.22
+tk init
 
 # Workaround for https://github.com/jsonnet-libs/k8s/issues/132
 echo "(import 'github.com/jsonnet-libs/k8s-libsonnet/1.22/main.libsonnet') + { extensions:: null }" > lib/k.libsonnet
@@ -58,8 +58,7 @@ elif [[ "$MODE" == "grafana-cloud" ]]; then
 		STACKS=$(jq -r '[.items[].slug] | join(",")' $INSTANCESFILE)
 		read -p "Please select your stack (available: $STACKS): " STACK
 
-		read -r -d '' GCLOUD_CONFIG <<EOF
-{
+GCLOUD_CONFIG="{
   _config+:: {
     apiKey: '$APIKEY',
     prometheus+: {
@@ -75,10 +74,9 @@ elif [[ "$MODE" == "grafana-cloud" ]]; then
       user: $(jq --arg STACK $STACK '.items[] | select(.slug==$STACK) | .htInstanceId' $INSTANCESFILE),
     },
   },
-}
-EOF
+}"
     install_env grafana-cloud "$GCLOUD_CONFIG"
-		rm $INSTANCESFILE
+	rm $INSTANCESFILE
     install_env tns-cloud
 else
     install_env loki            # Install loki logging app


### PR DESCRIPTION
The installer script throws an error and then fails silently.

[The call to tk init](https://github.com/grafana/tns/blob/31acfead8834ec7b5ec2aceabbe3bc25f70883b4/install#L38) tries to force the k8s version to 1.22, which is no longer supported by [k8s-libsonnet](https://github.com/jsonnet-libs/k8s-libsonnet).  This results in a Golang panic because the 1.22 files aren't found.  The panic doesn't seem to block the installation, but it's there on the screen for all to see.  This is fixed by removing the command line argument that forces the version to 1.22.

[Later in the script, the bash read command is used to generate a dynamic config for the Grafana instrumentation.](https://github.com/grafana/tns/blob/31acfead8834ec7b5ec2aceabbe3bc25f70883b4/install#L61-L79).  The read works as expected, generating the dynamic config. However, [by design](https://ss64.com/bash/read.html) when read finishes and encounters the EOF marker, it sets the errorlevel to 1.  [Because the -e option is set, even though no real error condition exists, the script exits rather than deploy the app.](https://github.com/grafana/tns/blob/31acfead8834ec7b5ec2aceabbe3bc25f70883b4/install#L3)  This is fixed by removing the read stanza and replacing it with an environment variable and command substitution.