### PR TITLE
Use Tanka Default K8S Version in Install Script

### DIFF
--- a/install
+++ b/install
@@ -35,7 +35,7 @@ fi
 mkdir "$BASEDIR/tanka" && cd "$BASEDIR/tanka"
 
 # Initialise Tanka
-tk init --k8s=1.22
+tk init
 
 # Workaround for https://github.com/jsonnet-libs/k8s/issues/132
 echo "(import 'github.com/jsonnet-libs/k8s-libsonnet/1.22/main.libsonnet') + { extensions:: null }" > lib/k.libsonnet


### PR DESCRIPTION
While following the local MLT setup [instructions](https://github.com/grafana/tns?tab=readme-ov-file#install-tns-demo-running-mlt-stack-locally), the install script will panic during `tk init` as it tries to rename a v1.22 file which is no longer provided by k8s-libsonnet. I saw that a similar error was [reported](https://github.com/grafana/tanka/issues/1023) and [fixed](https://github.com/grafana/tanka/pull/1010) (by setting v1.29 as the default version for Tanka) before.  This PR just unsets `--k8s=1.22` so that `tk init` uses the default version instead of a fixed, older version.

```bash
tns % ./install
GET https://github.com/jsonnet-libs/k8s-libsonnet/archive/f8b0d65c573f3b36040258fa69e90e13e7129083.tar.gz 200
panic: rename /Users/dmw/grafana/tns/tanka/vendor/.tmp/871a7c0eb23aed8af1f9669dca6623393336010528/1.22 /Users/dmw/grafana/tns/tanka/vendor/github.com/jsonnet-libs/k8s-libsonnet/1.22: no such file or directory

goroutine 1 [running]:
github.com/jsonnet-bundler/jsonnet-bundler/pkg.(*GitPackage).Install(0x140000603d0, {0x1004ed3e0, 0x100797920}, {0x140000268a0, 0x2a}, {0x14000026810, 0x2c}, {0x16fdab896, 0x4})
	github.com/jsonnet-bundler/jsonnet-bundler/pkg/git.go:228 +0x1244
github.com/jsonnet-bundler/jsonnet-bundler/pkg.download({{0x1400001e410, 0x0}, {0x16fdab896, 0x4}, {0x0, 0x0}, 0x0, {0x0, 0x0}}, {0x14000026810, ...}, ...)
	github.com/jsonnet-bundler/jsonnet-bundler/pkg/packages.go:316 +0x2e4
github.com/jsonnet-bundler/jsonnet-bundler/pkg.ensure(0x1400013acb0, {0x14000026810, 0x2c}, {0x0, 0x0}, 0x1400013ad20)
	github.com/jsonnet-bundler/jsonnet-bundler/pkg/packages.go:239 +0x488
github.com/jsonnet-bundler/jsonnet-bundler/pkg.Ensure({0x1400013acb0?, 0x0?}, {0x14000026810, 0x2c}, 0x1400001ebe0?)
	github.com/jsonnet-bundler/jsonnet-bundler/pkg/packages.go:55 +0x44
main.installCommand({0x14000026064?, 0x6?}, {0x100385f7c, 0x6}, {0x1400003a400, 0x3, 0x14000104e08?}, 0x0, {0x0, 0x0})
	github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb/install.go:86 +0x84c
main.Main()
	github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb/main.go:87 +0xc48
main.main()
	github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb/main.go:39 +0x1c
Installing k.libsonnet: exit status 2
```

First workaround I tried was to set  `--k8s` equal to the server version from the current context, but the following would still panic when using an older K8s version.

```bash
K8S_VERSION=$(kubectl version --context $CONTEXT -o json | jq -r '"\(.serverVersion.major).\(.serverVersion.minor)"')
tk init --k8s=$K8S_VERSION
```

Tested by deleting k3s cluster and re-running `./create-k3d-cluster` and `./install`.
