### PR TITLE
Move from Grafana Agent to Grafana alloy

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ You can also run the TNS demo without Kubernetes. Click [here](https://github.co
 
 The TNS demo uses `kubectl` to interact with the Kubernetes clusters. Click [here](https://kubernetes.io/docs/tasks/tools/install-kubectl/) for `kubectl` installation instructions.
 
+### Helm
+
+Helm is required by Tanka for using the Grafana Alloy helm chart in the TNS demo. Click [here](https://helm.sh/docs/intro/install/) for `helm` installation instructions.
+
 ### Tanka
 
 Tanka uses the Jsonnet language to interact with Kubernetes, via the `kubectl` tool. Click [here](https://tanka.dev/install#tanka) for installation instructions.

--- a/production/k8s-yamls-cloud/app-full.yaml
+++ b/production/k8s-yamls-cloud/app-full.yaml
@@ -71,7 +71,7 @@ spec:
         - http://db
         env:
         - name: JAEGER_AGENT_HOST
-          value: grafana-agent-traces.default.svc.cluster.local
+          value: alloy.default.svc.cluster.local
         - name: JAEGER_TAGS
           value: cluster=cloud,namespace=tns-cloud
         - name: JAEGER_SAMPLER_TYPE
@@ -107,7 +107,7 @@ spec:
         - -log.level=debug
         env:
         - name: JAEGER_AGENT_HOST
-          value: grafana-agent-traces.default.svc.cluster.local
+          value: alloy.default.svc.cluster.local
         - name: JAEGER_TAGS
           value: cluster=cloud,namespace=tns-cloud
         - name: JAEGER_SAMPLER_TYPE
@@ -144,7 +144,7 @@ spec:
         - http://app
         env:
         - name: JAEGER_AGENT_HOST
-          value: grafana-agent-traces.default.svc.cluster.local
+          value: alloy.default.svc.cluster.local
         - name: JAEGER_TAGS
           value: cluster=cloud,namespace=tns-cloud
         - name: JAEGER_SAMPLER_TYPE

--- a/production/sample/default/main.jsonnet
+++ b/production/sample/default/main.jsonnet
@@ -1,6 +1,8 @@
+local tanka = import 'github.com/grafana/jsonnet-libs/tanka-util/main.libsonnet';
 local gragent = import 'grafana-agent/v2/main.libsonnet';
 local k = import 'ksonnet-util/kausal.libsonnet';
 local tns_mixin = import 'tns-mixin/mixin.libsonnet';
+local helm = tanka.helm.new(std.thisFile);
 
 (import 'ksonnet-util/kausal.libsonnet') +
 (import 'prometheus-ksonnet/grafana/grafana.libsonnet') +
@@ -28,94 +30,801 @@ local tns_mixin = import 'tns-mixin/mixin.libsonnet';
   local ingressRule = k.networking.v1.ingressRule,
   local service = k.core.v1.service,
 
-  // Create a Grafana Agent daemon set to collect metrics, logs, and traces
+  // Deploys Grafana Alloy to collect metrics, logs, and traces
   //
   // Metrics, logs, and traces are enriched with Kubernetes metadata. Metrics and logs from
   // the local Kubernetes node are collected while traces use a push model (clients send traces
   // to the agent).
-  //
-  // The agent runs as a privileged container and as root since this is a requirement of
-  // collecting logs. The path /var/log on the Kubernetes node is mounted into the container
-  // along with /var/lib/docker/containers.
-  //
-  // A service for the agent is created so that other pods within the cluster can send traces
-  // to the agent.
-  daemonset_agent:
-    gragent.new(name='grafana-agent', namespace='default') +
-    gragent.withDaemonSetController() +
-    gragent.withService({}) +
-    gragent.withLogVolumeMounts({}) +
-    gragent.withLogPermissions({}) +
-    gragent.withConfigHash(true) +
-    gragent.withPortsMixin([
-      // Create container ports for the various ways that the agent can collect traces.
-      containerPort.new('thrift-compact', 6831) + containerPort.withProtocol('UDP'),
-      containerPort.new('thrift-binary', 6832) + containerPort.withProtocol('UDP'),
-      containerPort.new('thrift-http', 14268),
-      containerPort.new('thrift-grpc', 14250),
-    ]) +
-    gragent.withAgentConfig({
-      server: {
-        log_level: 'debug',
-      },
-      metrics+: {
-        global+: {
-          scrape_interval: '15s',
-          external_labels: {
-            cluster: 'tns',
-          },
-        },
-        wal_directory: '/tmp/agent/prom',
-        configs: [
+
+  alloy_deployment: helm.template('alloy', '../../vendor/github.com/grafana/alloy/operations/helm/charts/alloy', {
+    namespace: 'default',
+    values: {
+      alloy: {
+        extraPorts: [
           {
-            name: 'kubernetes-metrics',
-            remote_write: [
-              {
-                url: 'http://mimir.mimir.svc.cluster.local/api/v1/push',
-                send_exemplars: true,
-              },
-            ],
-            scrape_configs: gragent.newKubernetesMetrics({}),
+            name: 'thrift-compact',
+            port: 6831,
+            targetPort: 6831,
+            protocol: 'UDP',
+          },
+          {
+            name: 'thrift-binary',
+            port: 6832,
+            targetPort: 6832,
+            protocol: 'UDP',
+          },
+          {
+            name: 'thrift-http',
+            port: 14268,
+            targetPort: 14268,
+            protocol: 'TCP',
+          },
+          {
+            name: 'thrift-grpc',
+            port: 14250,
+            targetPort: 14250,
+            protocol: 'TCP',
           },
         ],
+        configMap: {
+          content: |||
+            discovery.kubernetes "service" {
+            	role = "service"
+            }
+
+            discovery.kubernetes "pod" {
+            	role = "pod"
+            }
+
+            discovery.kubernetes "kube_system" {
+            	role = "pod"
+
+            	namespaces {
+            		names = ["kube-system"]
+            	}
+            }
+
+            discovery.kubernetes "node" {
+            	role = "node"
+            }
+
+            discovery.relabel "service" {
+            	targets = discovery.kubernetes.service.targets
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_service_label_component"]
+            		regex         = "apiserver"
+            		action        = "keep"
+            	}
+            }
+
+            discovery.relabel "pod" {
+            	targets = discovery.kubernetes.pod.targets
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_scrape"]
+            		regex         = "false"
+            		action        = "drop"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_container_port_name"]
+            		regex         = ".*-metrics"
+            		action        = "keep"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_scheme"]
+            		regex         = "(https?)"
+            		target_label  = "__scheme__"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_path"]
+            		regex         = "(.+)"
+            		target_label  = "__metrics_path__"
+            	}
+
+            	rule {
+            		source_labels = ["__address__", "__meta_kubernetes_pod_annotation_prometheus_io_port"]
+            		regex         = "(.+?)(\\:\\d+)?;(\\d+)"
+            		target_label  = "__address__"
+            		replacement   = "$1:$3"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_label_name"]
+            		regex         = ""
+            		action        = "drop"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_label_name"]
+            		separator     = "/"
+            		target_label  = "job"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_namespace"]
+            		target_label  = "namespace"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_name"]
+            		target_label  = "pod"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_container_name"]
+            		target_label  = "container"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_name", "__meta_kubernetes_pod_container_name", "__meta_kubernetes_pod_container_port_name"]
+            		separator     = ":"
+            		target_label  = "instance"
+            	}
+
+            	rule {
+            		regex       = "__meta_kubernetes_pod_annotation_prometheus_io_param_(.+)"
+            		replacement = "__param_$1"
+            		action      = "labelmap"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_phase"]
+            		regex         = "Succeeded|Failed"
+            		action        = "drop"
+            	}
+            }
+
+            discovery.relabel "kube_state_metrics" {
+            	targets = discovery.kubernetes.kube_system.targets
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_label_name"]
+            		regex         = "kube-state-metrics"
+            		action        = "keep"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_name", "__meta_kubernetes_pod_container_name", "__meta_kubernetes_pod_container_port_name"]
+            		separator     = ":"
+            		target_label  = "instance"
+            	}
+            }
+
+            discovery.relabel "node_exporter" {
+            	targets = discovery.kubernetes.kube_system.targets
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_label_name"]
+            		regex         = "node-exporter"
+            		action        = "keep"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_node_name"]
+            		target_label  = "instance"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_namespace"]
+            		target_label  = "namespace"
+            	}
+            }
+
+            discovery.relabel "kubelet" {
+            	targets = discovery.kubernetes.node.targets
+
+            	rule {
+            		target_label = "__address__"
+            		replacement  = "kubernetes.default.svc.cluster.local:443"
+            	}
+
+            	rule {
+            		target_label = "__scheme__"
+            		replacement  = "https"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_node_name"]
+            		regex         = "(.+)"
+            		target_label  = "__metrics_path__"
+            		replacement   = "/api/v1/nodes/$1/proxy/metrics"
+            	}
+            }
+
+            discovery.relabel "cadvisor" {
+            	targets = discovery.kubernetes.node.targets
+
+            	rule {
+            		target_label = "__address__"
+            		replacement  = "kubernetes.default.svc.cluster.local:443"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_node_name"]
+            		regex         = "(.+)"
+            		target_label  = "__metrics_path__"
+            		replacement   = "/api/v1/nodes/$1/proxy/metrics/cadvisor"
+            	}
+            }
+
+            prometheus.scrape "default_kubernetes" {
+            	targets         = discovery.relabel.service.output
+            	forward_to      = [prometheus.relabel.service.receiver]
+            	job_name        = "default/kubernetes"
+            	scrape_interval = "15s"
+            	scheme          = "https"
+
+            	authorization {
+            		type             = "Bearer"
+            		credentials_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+            	}
+
+            	tls_config {
+            		ca_file     = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+            		server_name = "kubernetes"
+            	}
+            }
+
+            prometheus.scrape "pods" {
+            	targets         = discovery.relabel.pod.output
+            	forward_to      = [prometheus.remote_write.kubernetes_metrics.receiver]
+            	job_name        = "kubernetes-pods"
+            	scrape_interval = "15s"
+            }
+
+            prometheus.scrape "kube_state_metrics" {
+            	targets         = discovery.relabel.kube_state_metrics.output
+            	forward_to      = [prometheus.remote_write.kubernetes_metrics.receiver]
+            	job_name        = "kube-system/kube-state-metrics"
+            	scrape_interval = "15s"
+            }
+
+            prometheus.scrape "node_exporter" {
+            	targets         = discovery.relabel.node_exporter.output
+            	forward_to      = [prometheus.remote_write.kubernetes_metrics.receiver]
+            	job_name        = "kube-system/node-exporter"
+            	scrape_interval = "15s"
+            }
+
+            prometheus.scrape "kubelet" {
+            	targets         = discovery.relabel.kubelet.output
+            	forward_to      = [prometheus.remote_write.kubernetes_metrics.receiver]
+            	job_name        = "kube-system/kubelet"
+            	scrape_interval = "15s"
+
+            	authorization {
+            		type             = "Bearer"
+            		credentials_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+            	}
+
+            	tls_config {
+            		ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+            	}
+            }
+
+            prometheus.scrape "cadvisor" {
+            	targets         = discovery.relabel.cadvisor.output
+            	forward_to      = [prometheus.relabel.cadvisor.receiver]
+            	job_name        = "kube-system/cadvisor"
+            	scrape_interval = "15s"
+            	scheme          = "https"
+
+            	authorization {
+            		type             = "Bearer"
+            		credentials_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+            	}
+
+            	tls_config {
+            		ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+            	}
+            }
+
+            prometheus.relabel "service" {
+            	forward_to = [prometheus.remote_write.kubernetes_metrics.receiver]
+
+            	rule {
+            		source_labels = ["__name__"]
+            		regex         = "workqueue_queue_duration_seconds_bucket|process_cpu_seconds_total|process_resident_memory_bytes|workqueue_depth|rest_client_request_duration_seconds_bucket|workqueue_adds_total|up|rest_client_requests_total|apiserver_request_total|go_goroutines"
+            		action        = "keep"
+            	}
+            }
+
+            prometheus.relabel "cadvisor" {
+            	forward_to = [prometheus.remote_write.kubernetes_metrics.receiver]
+
+            	rule {
+            		source_labels = ["__name__", "image"]
+            		regex         = "container_([a-z_]+);"
+            		action        = "drop"
+            	}
+
+            	rule {
+            		source_labels = ["__name__"]
+            		regex         = "container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)"
+            		action        = "drop"
+            	}
+            }
+
+            prometheus.remote_write "kubernetes_metrics" {
+            	external_labels = {
+            		cluster = "tns",
+            	}
+
+            	endpoint {
+            		name = "kubernetes-metrics-9ba231"
+            		url  = "http://mimir.mimir.svc.cluster.local/api/v1/push"
+
+            		queue_config { }
+
+            		metadata_config { }
+            	}
+            }
+
+            discovery.relabel "log_pod" {
+            	targets = discovery.kubernetes.pod.targets
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_label_name"]
+            		target_label  = "__service__"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_node_name"]
+            		target_label  = "__host__"
+            	}
+
+            	rule {
+            		source_labels = ["__service__"]
+            		regex         = ""
+            		action        = "drop"
+            	}
+
+            	rule {
+            		regex  = "__meta_kubernetes_pod_label_(.+)"
+            		action = "labelmap"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_namespace", "__service__"]
+            		separator     = "/"
+            		target_label  = "job"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_namespace"]
+            		target_label  = "namespace"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_name"]
+            		target_label  = "pod"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_container_name"]
+            		target_label  = "container"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+            		separator     = "/"
+            		target_label  = "__path__"
+            		replacement   = "/var/log/pods/*$1/*.log"
+            	}
+            }
+
+            local.file_match "pod" {
+            	path_targets = discovery.relabel.log_pod.output
+            }
+
+            loki.process "pod" {
+            	forward_to = [loki.write.kubernetes.receiver]
+
+            	stage.docker { }
+            }
+
+            loki.source.kubernetes "pod" {
+            	targets               = local.file_match.pod.targets
+            	forward_to            = [loki.process.pod.receiver]
+            }
+
+            discovery.relabel "pods_app" {
+            	targets = discovery.kubernetes.pod.targets
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_label_name"]
+            		regex         = ".+"
+            		action        = "drop"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_label_app"]
+            		target_label  = "__service__"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_node_name"]
+            		target_label  = "__host__"
+            	}
+
+            	rule {
+            		source_labels = ["__service__"]
+            		regex         = ""
+            		action        = "drop"
+            	}
+
+            	rule {
+            		regex  = "__meta_kubernetes_pod_label_(.+)"
+            		action = "labelmap"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_namespace", "__service__"]
+            		separator     = "/"
+            		target_label  = "job"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_namespace"]
+            		target_label  = "namespace"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_name"]
+            		target_label  = "pod"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_container_name"]
+            		target_label  = "container"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+            		separator     = "/"
+            		target_label  = "__path__"
+            		replacement   = "/var/log/pods/*$1/*.log"
+            	}
+            }
+
+            local.file_match "pods_app" {
+            	path_targets = discovery.relabel.pods_app.output
+            }
+
+            loki.process "pods_app" {
+            	forward_to = [loki.write.kubernetes.receiver]
+
+            	stage.docker { }
+            }
+
+            loki.source.kubernetes "pods_app" {
+            	targets               = local.file_match.pods_app.targets
+            	forward_to            = [loki.process.pods_app.receiver]
+            }
+
+            discovery.relabel "direct_controllers" {
+            	targets = discovery.kubernetes.pod.targets
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_label_name", "__meta_kubernetes_pod_label_app"]
+            		separator     = ""
+            		regex         = ".+"
+            		action        = "drop"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_controller_name"]
+            		regex         = "[0-9a-z-.]+-[0-9a-f]{8,10}"
+            		action        = "drop"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_controller_name"]
+            		target_label  = "__service__"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_node_name"]
+            		target_label  = "__host__"
+            	}
+
+            	rule {
+            		source_labels = ["__service__"]
+            		regex         = ""
+            		action        = "drop"
+            	}
+
+            	rule {
+            		regex  = "__meta_kubernetes_pod_label_(.+)"
+            		action = "labelmap"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_namespace", "__service__"]
+            		separator     = "/"
+            		target_label  = "job"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_namespace"]
+            		target_label  = "namespace"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_name"]
+            		target_label  = "pod"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_container_name"]
+            		target_label  = "container"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+            		separator     = "/"
+            		target_label  = "__path__"
+            		replacement   = "/var/log/pods/*$1/*.log"
+            	}
+            }
+
+            local.file_match "direct_controllers" {
+            	path_targets = discovery.relabel.direct_controllers.output
+            }
+
+            loki.process "direct_controllers" {
+            	forward_to = [loki.write.kubernetes.receiver]
+
+            	stage.docker { }
+            }
+
+            loki.source.kubernetes "direct_controllers" {
+            	targets               = local.file_match.direct_controllers.targets
+            	forward_to            = [loki.process.direct_controllers.receiver]
+            }
+
+            discovery.relabel "indirect_controller" {
+            	targets = discovery.kubernetes.pod.targets
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_label_name", "__meta_kubernetes_pod_label_app"]
+            		separator     = ""
+            		regex         = ".+"
+            		action        = "drop"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_controller_name"]
+            		regex         = "[0-9a-z-.]+-[0-9a-f]{8,10}"
+            		action        = "keep"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_controller_name"]
+            		regex         = "([0-9a-z-.]+)-[0-9a-f]{8,10}"
+            		target_label  = "__service__"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_node_name"]
+            		target_label  = "__host__"
+            	}
+
+            	rule {
+            		source_labels = ["__service__"]
+            		regex         = ""
+            		action        = "drop"
+            	}
+
+            	rule {
+            		regex  = "__meta_kubernetes_pod_label_(.+)"
+            		action = "labelmap"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_namespace", "__service__"]
+            		separator     = "/"
+            		target_label  = "job"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_namespace"]
+            		target_label  = "namespace"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_name"]
+            		target_label  = "pod"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_container_name"]
+            		target_label  = "container"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+            		separator     = "/"
+            		target_label  = "__path__"
+            		replacement   = "/var/log/pods/*$1/*.log"
+            	}
+            }
+
+            local.file_match "indirect_controller" {
+            	path_targets = discovery.relabel.indirect_controller.output
+            }
+
+            loki.process "indirect_controller" {
+            	forward_to = [loki.write.kubernetes.receiver]
+
+            	stage.docker { }
+            }
+
+            loki.source.kubernetes "indirect_controller" {
+            	targets               = local.file_match.indirect_controller.targets
+            	forward_to            = [loki.process.indirect_controller.receiver]
+            }
+
+            discovery.relabel "pods_static" {
+            	targets = discovery.kubernetes.pod.targets
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror"]
+            		regex         = ""
+            		action        = "drop"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_label_component"]
+            		target_label  = "__service__"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_node_name"]
+            		target_label  = "__host__"
+            	}
+
+            	rule {
+            		source_labels = ["__service__"]
+            		regex         = ""
+            		action        = "drop"
+            	}
+
+            	rule {
+            		regex  = "__meta_kubernetes_pod_label_(.+)"
+            		action = "labelmap"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_namespace", "__service__"]
+            		separator     = "/"
+            		target_label  = "job"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_namespace"]
+            		target_label  = "namespace"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_name"]
+            		target_label  = "pod"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_container_name"]
+            		target_label  = "container"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+            		separator     = "/"
+            		target_label  = "__path__"
+            		replacement   = "/var/log/pods/*$1/*.log"
+            	}
+            }
+
+            local.file_match "pods_static" {
+            	path_targets = discovery.relabel.pods_static.output
+            }
+
+            loki.process "pods_static" {
+            	forward_to = [loki.write.kubernetes.receiver]
+
+            	stage.docker { }
+            }
+
+            loki.source.kubernetes "pods_static" {
+            	targets               = local.file_match.pods_static.targets
+            	forward_to            = [loki.process.pods_static.receiver]
+            }
+
+            loki.write "kubernetes" {
+            	endpoint {
+            		url = "http://loki.loki.svc.cluster.local:3100/loki/api/v1/push"
+            	}
+            	external_labels = {
+            		cluster = "tns",
+            	}
+            }
+
+            otelcol.receiver.jaeger "default" {
+            	protocols {
+            		grpc {
+            			endpoint = "0.0.0.0:14250"
+            		}
+
+            		thrift_http {
+            			endpoint = "0.0.0.0:14268"
+            		}
+
+            		thrift_binary {
+            			endpoint        = "0.0.0.0:6832"
+            			max_packet_size = "63KiB488B"
+            		}
+
+            		thrift_compact {
+            			endpoint        = "0.0.0.0:6831"
+            			max_packet_size = "63KiB488B"
+            		}
+            	}
+
+            	output {
+            		traces = [otelcol.processor.discovery.default.input]
+            	}
+            }
+
+            discovery.relabel "pods_otel" {
+            	targets = discovery.kubernetes.pod.targets
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_namespace"]
+            		target_label  = "namespace"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_name"]
+            		target_label  = "pod"
+            	}
+
+            	rule {
+            		source_labels = ["__meta_kubernetes_pod_container_name"]
+            		target_label  = "container"
+            	}
+            }
+
+            otelcol.processor.discovery "default" {
+            	targets          = discovery.relabel.pods_otel.output
+            	pod_associations = []
+
+            	output {
+            		traces = [otelcol.exporter.otlp.tempo.input]
+            	}
+            }
+
+            otelcol.exporter.otlp "tempo" {
+            	retry_on_failure {
+            		max_elapsed_time = "1m0s"
+            	}
+
+            	client {
+            		endpoint = "tempo.tempo.svc.cluster.local:55680"
+
+            		tls {
+            			insecure = true
+            		}
+            	}
+            }
+          |||,
+
+        },
       },
-      logs+: {
-        positions_directory: '/tmp/agent/loki',
-        configs: [{
-          name: 'kubernetes-logs',
-          clients: [{
-            url: 'http://loki.loki.svc.cluster.local:3100/loki/api/v1/push',
-            external_labels: {
-              cluster: 'tns',
-            },
-          }],
-          scrape_configs: gragent.newKubernetesLogs({}),
-        }],
-      },
-      traces+: {
-        configs: [{
-          name: 'kubernetes-traces',
-          receivers: {
-            jaeger: {
-              protocols: {
-                grpc: null,
-                thrift_binary: null,
-                thrift_compact: null,
-                thrift_http: null,
-              },
-            },
-          },
-          remote_write: [{
-            endpoint: 'tempo.tempo.svc.cluster.local:55680',
-            insecure: true,
-            retry_on_failure: {
-              enabled: true,
-            },
-          }],
-          scrape_configs: gragent.newKubernetesTraces({}),
-        }],
-      },
-    }),
+    },
+  }),
 
   nginx_service+:
     service.mixin.spec.withType('ClusterIP') +

--- a/production/sample/jsonnetfile.json
+++ b/production/sample/jsonnetfile.json
@@ -13,6 +13,15 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/grafana/alloy.git",
+          "subdir": "operations/helm"
+        }
+      },
+      "version": "main"
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/grafana/jsonnet-libs.git",
           "subdir": "ksonnet-util"
         }
@@ -42,6 +51,15 @@
         "git": {
           "remote": "https://github.com/grafana/jsonnet-libs.git",
           "subdir": "prometheus-ksonnet"
+        }
+      },
+      "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "tanka-util"
         }
       },
       "version": "master"

--- a/production/sample/jsonnetfile.lock.json
+++ b/production/sample/jsonnetfile.lock.json
@@ -14,6 +14,16 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/grafana/alloy.git",
+          "subdir": "operations/helm"
+        }
+      },
+      "version": "dfb75ba78830265e02f536e982d9d1bbd414acd9",
+      "sum": "tmBVAiKHzz4Qqz2FoHRH3a2A1gxA+kzJDAr0Cv73LjU="
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/grafana/grafana.git",
           "subdir": "grafana-mixin"
         }
@@ -144,12 +154,32 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "tanka-util"
+        }
+      },
+      "version": "e6f3db92b7d61f348aed812087f2865b207d7148",
+      "sum": "ShSIissXdvCy1izTCDZX6tY7qxCoepE5L+WJ52Hw7ZQ="
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/grafana/loki.git",
           "subdir": "production/ksonnet/promtail"
         }
       },
       "version": "f22dbc2190921e70d38e8b915aa64964879b6b78",
       "sum": "d7azenENzcvtlgkTeDFWk2tL1QXPSiYRhrGc1Klroa8="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/docsonnet.git",
+          "subdir": "doc-util"
+        }
+      },
+      "version": "6ac6c69685b8c29c54515448eaca583da2d88150",
+      "sum": "BrAL/k23jq+xy9oA7TWIhUx07dsA/QLm3g7ktCwe//U="
     },
     {
       "source": {

--- a/production/sample/tns-cloud/main.jsonnet
+++ b/production/sample/tns-cloud/main.jsonnet
@@ -5,7 +5,7 @@ tns {
     namespace: 'tns-cloud',
     tns+: {
       jaeger+: {
-        host: 'grafana-agent.grafana-cloud.svc.cluster.local',
+        host: 'alloy.grafana-cloud.svc.cluster.local',
         tags: 'cluster=tns-cluster,namespace=tns-cloud',
       },
     },

--- a/production/tns/config.libsonnet
+++ b/production/tns/config.libsonnet
@@ -2,7 +2,7 @@
   _config+:: {
     tns+: {
       jaeger: {
-        host: 'grafana-agent.default.svc.cluster.local',
+        host: 'alloy.default.svc.cluster.local',
         tags: 'cluster=tns,namespace=tns',
         sampler_type: 'const',
         sampler_param: '1',


### PR DESCRIPTION
Alloy only supports Helm (and doesn't include Jsonnet support out-of-the-box), so Helm has been added as a dependency in the README.

This is a work in progress I put together; I don't plan to continue development, but it can serve as a foundation for anyone interested in migrating to Alloy.

- [ ] The App/db/loadgen service must be restarted after Alloy is initialized (possible issue with the Jaeger client library).
- [ ] Logging functionality is not working (needs investigation).
- [ ] Helm has not yet been integrated into the CI pipeline.