### PR TITLE
fix: Fix potential hang when bringing down local env

### DIFF
--- a/production/docker-compose/docker-compose.yml
+++ b/production/docker-compose/docker-compose.yml
@@ -2,6 +2,10 @@ x-logging: &default-logging
   driver: loki
   options:
     loki-url: 'http://localhost:3100/api/prom/push'
+    # Limit the number of retries to avoid issues during shutdown. A race
+    # condition between the driver and containers can cause Loki to stop before
+    # all logs are received, triggering excessive retries with a slow backoff.
+    loki-retries: 3
     labels: namespace
     loki-relabel-config: |
       - action: replace


### PR DESCRIPTION
There is a common hang when bringing down the environment created by `production/docker-compose` (reported by #31) which is due to a race condition between the Loki service and the driver when the driver still has logs to send, but the service is no longer running.

This limit the number of retries, which seems like the only way to ensure more timely shutdown. We could add a dependency to ensure Loki shutdown last, but that would still not guarantee it, because Loki can generate logs as well.

You can almost guarantee to trigger it by applying the following patch:
```patch
diff --git a/production/docker-compose/docker-compose.yml b/production/docker-compose/docker-compose.yml
index 55be178..982d071 100644
--- a/production/docker-compose/docker-compose.yml
+++ b/production/docker-compose/docker-compose.yml
@@ -140,6 +140,8 @@ services:
 
   loki:
     image: grafana/loki:2.3.0
+    depends_on:
+      - loadgen
     command:
       - -config.file=/etc/loki/local-config.yaml
       - -table-manager.retention-period=1d
```