### PR TITLE
Pin Tempo docker image version to 2.9.2

### DIFF
--- a/production/tempo/config.libsonnet
+++ b/production/tempo/config.libsonnet
@@ -1,7 +1,7 @@
 {
   _images+:: {
-    tempo: 'grafana/tempo:latest',
-    tempo_vulture: 'grafana/tempo-vulture:latest',
+    tempo: 'grafana/tempo:2.9.2',
+    tempo_vulture: 'grafana/tempo-vulture:2.9.2',
   },
 
   _config+:: {


### PR DESCRIPTION
As Grafana Tempo main branch is going towards v3, some breaking changes are happening and the configuration included in this repo at `production/docker-compose/tempo.yaml` doesn't work.

This PR pins the docker image version to the latest stable version available (2.9.2).