### PR TITLE
Fix demo app redirects and vote link dropping port/path prefix

### DIFF
--- a/app/index.html.tmpl
+++ b/app/index.html.tmpl
@@ -31,7 +31,7 @@
                         <td align="right" valign="top" class="title"><span class="rank">{{ .Rank }}.</span></td>
                         <td valign="top" class="votelinks">
                            <center>
-                              <a id='up_{{ .ID }}' href='vote?id={{ .ID }}&amp;how=up'>
+                              <a id='up_{{ .ID }}' href="/vote?id={{ .ID }}&amp;how=up">
                                  <div class='votearrow' title='upvote'></div>
                               </a>
                            </center>

--- a/app/main.go
+++ b/app/main.go
@@ -257,9 +257,13 @@ func (a *app) Post(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Implement PRG pattern to prevent double-POST.
-	newURL := strings.TrimSuffix(req.RequestURI, "/post")
-	http.Redirect(w, req, newURL, http.StatusFound)
+	// Implement PRG pattern to prevent double-POST. Use a relative redirect
+	// ("./") so the browser resolves it against the URL it actually requested,
+	// preserving scheme, host, port and any reverse-proxy path prefix (e.g.
+	// /tns-demo/). http.Redirect would rewrite this to a host-rooted "/", which
+	// a proxy then re-absolutizes against $host — dropping the :8080 port.
+	w.Header().Set("Location", "./")
+	w.WriteHeader(http.StatusFound)
 }
 
 func (a *app) Vote(w http.ResponseWriter, r *http.Request) {
@@ -314,7 +318,11 @@ func (a *app) Vote(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Implement PRG pattern to prevent double-POST.
-	newURL := strings.TrimSuffix(req.RequestURI, "/vote")
-	http.Redirect(w, req, newURL, http.StatusFound)
+	// Implement PRG pattern to prevent double-POST. Use a relative redirect
+	// ("./") so the browser resolves it against the URL it actually requested,
+	// preserving scheme, host, port and any reverse-proxy path prefix (e.g.
+	// /tns-demo/). http.Redirect would rewrite this to a host-rooted "/", which
+	// a proxy then re-absolutizes against $host — dropping the :8080 port.
+	w.Header().Set("Location", "./")
+	w.WriteHeader(http.StatusFound)
 }


### PR DESCRIPTION
## Summary

Two bugs broke the post/vote flow when the demo app is accessed through the nginx-directory reverse proxy at `/tns-demo/` (and the `:8080` port-forward):

- **Redirect dropped the port.** The PRG redirect emitted a host-rooted `Location: /`. The proxy rewrites that via `proxy_redirect "/" "/tns-demo/"` and re-absolutizes it against `$host`, which omits the port — sending the browser from `:8080` to `:80`. Now emits a relative `./` so the browser resolves it against the URL it actually requested, preserving scheme/host/**port** and the `/tns-demo/` path prefix.

- **Vote link dropped the path prefix.** The vote link was relative and single-quoted (`href='vote?...'`), so the proxy's `sub_filter` (which only matches `href="/`) left it unrewritten. From a page served at `/tns-demo` (no trailing slash) it resolved to `/vote?...` and **404'd**. Made it root-absolute and double-quoted to match the form's `action="/post"`, so `sub_filter` rewrites it to `/tns-demo/vote` under the proxy and it stays absolute when accessed directly.

## Test plan

Verified end-to-end in a k3d cluster, both through the nginx proxy and via a direct port-forward:

| Path | Vote link rendered as | Click result |
|---|---|---|
| Proxy `/tns-demo` (no slash) | `/tns-demo/vote?…` | 302 → `…/tns-demo/` (port kept) ✅ |
| Direct `/` | `/vote?…` | 302 → `/` (port kept) ✅ |

Posts and votes round-trip to `db` and the submitted links appear on the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)