### PR TITLE
Publish images to Docker Hub via GAR mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,14 +8,6 @@ workflows:
     - build
     - staticcheck-go
     - lint-jsonnet
-    - publish:
-        requires:
-        - test
-        - build
-        - staticcheck-go
-        filters:
-          branches:
-            only: main
 
 defaults: &defaults
   docker:
@@ -73,51 +65,3 @@ jobs:
           name: Build Images
           command: |
             make
-
-      - run:
-          name: Save Images
-          command: |
-            mkdir images/
-            docker save grafana/tns-loadgen:latest -o ./images/loadgen
-            docker save grafana/tns-app:latest -o ./images/app
-            docker save grafana/tns-db:latest -o ./images/db
-
-      - save_cache:
-          key: v1-tns-{{ .Branch }}-{{ .Revision }}
-          paths:
-          - images/
-
-  publish:
-    <<: *defaults
-    steps:
-      - checkout
-      - setup_remote_docker
-
-      - restore_cache:
-          key: v1-tns-{{ .Branch }}-{{ .Revision }}
-
-      - run:
-          name: Install Docker client
-          command: |
-            set -x
-            VER="17.03.0-ce"
-            curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
-            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-            mv /tmp/docker/* /usr/bin
-
-      - run:
-          name: Load Images
-          command: |
-            docker load -i ./images/loadgen
-            docker load -i ./images/app
-            docker load -i ./images/db
-
-      - run:
-          name: Push Images
-          command: |
-            if [ -n "$DOCKER_USER" ]; then
-              docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" &&
-              docker push grafana/tns-loadgen:latest
-              docker push grafana/tns-app:latest
-              docker push grafana/tns-db:latest
-            fi

--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -17,6 +17,10 @@ jobs:
       GOARCH: amd64
       CGO_ENABLED: 0
       GO111MODULE: on
+      # Push to the GAR mirror repo; gar-image-mirror copies these to
+      # docker.io/grafana/<image>. See grafana/deployment_tools
+      # docs/platform/gar-image-mirror.md.
+      DOCKER_IMAGE_BASE: us-docker.pkg.dev/grafanalabs-global/dockerhub-tns-prod-mirror
     steps:
     - name: Checkout Code
       uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -26,8 +30,10 @@ jobs:
     - name: Set up Docker buildx
       uses: docker/setup-buildx-action@1583c0f09d26c58c59d25b0eef29792b7ce99d9a
 
-    - name: Login to DockerHub (from Vault)
-      uses: grafana/shared-workflows/actions/dockerhub-login@bca48b60029f80d2ea7c1a6bd1a49ffa7915a9e3
+    - name: Login to GAR
+      uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+      with:
+        registry: us-docker.pkg.dev
 
     - name: Build
       run: make build


### PR DESCRIPTION
## Summary

The shared Docker Hub write token used by CI has been disabled. Per [`deployment_tools/docs/platform/gar-image-mirror.md`](https://github.com/grafana/deployment_tools/blob/master/docs/platform/gar-image-mirror.md), images must now be pushed to a repo-scoped GAR mirror repo via a short-lived OIDC token; the `gar-image-mirror` service copies them to `docker.io/grafana/<image>`.

This is **part 3** of the migration (the workflow change). Parts 1 & 2 (GAR repo + mirror mapping) are in grafana/deployment_tools#609157.

### Changes

- **GH Actions** (`build-and-push-images.yml`) — the active publisher:
  - Replace the `dockerhub-login` step with `login-to-gar` (`us-docker.pkg.dev`).
  - Set `DOCKER_IMAGE_BASE=us-docker.pkg.dev/grafanalabs-global/dockerhub-tns-prod-mirror` so `make build`/`make publish` tag and push to GAR. (`id-token: write` was already present.)
- **CircleCI** (`.circleci/config.yml`):
  - Remove the `publish` job, which pushed `grafana/tns-*:latest` straight to Docker Hub using the now-disabled shared token. CircleCI is no longer connected to this repo (only the GH Actions `build` check reports), so this was dead, Docker-Hub-direct config.
  - Drop the orphaned *Save Images* / `save_cache` steps that only fed it. The `build` job is kept as a build check; it no longer saves or pushes images.

The Makefile default `DOCKER_IMAGE_BASE=grafana` is intentionally unchanged — local dev relies on `grafana/tns-*` image names; the GAR base is injected only in CI.

## Order of operations

> [!IMPORTANT]
> Merge this **after** grafana/deployment_tools#609157 is applied (the GAR repo must exist and the mirror mapping must be live), otherwise the publish step will fail pushing to a non-existent GAR repo.

## Verifying (after merge to main)

- Image appears in GAR: `gcloud artifacts docker images list us-docker.pkg.dev/grafanalabs-global/dockerhub-tns-prod-mirror`
- Then shows up on Docker Hub at `docker.io/grafana/tns-{app,db,loadgen,lint}:<sha>` shortly after (mirroring is async).

🤖 Generated with [Claude Code](https://claude.com/claude-code)