### PR TITLE
fix: repair lint image build on alpine 3.23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor
 .volume
 production/tns-mixin/jsonnetfile.lock.json
 .DS_Store
+.idea

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .ONESHELL:
 .DELETE_ON_ERROR:
 SHELL       := sh
+.SHELLFLAGS  := -ec
 MAKEFLAGS   += --warn-undefined-variables
 MAKEFLAGS   += --no-builtin-rule
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ If you already have a K8s cluster *and* cloud metrics, logs, and traces services
     ```sh
     kubectl get pods -n tns-cloud
     ```
-    If all the pods are listed as either `running`, your app is ready for use.
+    If all the pods are listed as either `running` or `completed`, your app is ready for use.
 
 ## Install TNS demo app connected to Grafana Cloud (`grafana-cloud` option)
 
@@ -180,7 +180,7 @@ Note: this requires an existing K8S cluster.
     ```sh
     kubectl get pods -n tns-cloud
     ```
-	If all the pods are listed as either `running`, your app is ready for use.
+	If all the pods are listed as either `running` or `completed`, your app is ready for use.
 
 
 After a few minutes, you will see metrics arriving in your Grafana instance. At this point, you can also enable the [Kubernetes Integration](https://grafana.com/docs/grafana-cloud/kubernetes-monitoring/) - the agent is already configured for you!

--- a/lint-image/Dockerfile
+++ b/lint-image/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a50
 RUN apk add --no-cache git make g++
 RUN git clone https://github.com/google/jsonnet && \
     git  -C jsonnet checkout v0.14.0 && \
-    make -C jsonnet 2LDFLAGS=-static && \
+    make -C jsonnet LDFLAGS=-static jsonnet jsonnetfmt && \
     cp jsonnet/jsonnet /usr/bin && \
     cp jsonnet/jsonnetfmt /usr/bin
 
@@ -16,7 +16,7 @@ RUN git clone https://github.com/jsonnet-bundler/jsonnet-bundler /jsonnet-bundle
     make install
 
 FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
-RUN apk add --no-cache git make libgcc libstdc++ zip
+RUN apk add --no-cache git make zip
 COPY --from=jsonnet-builder /usr/bin/jsonnetfmt /usr/bin
 COPY --from=jsonnet-builder /usr/bin/jsonnet /usr/bin
 COPY --from=jb-builder /go/bin/jb /usr/bin


### PR DESCRIPTION
## Summary

Repair the `build-and-push-images` workflow, which has been failing on `main` since the renovate bump to `alpine:3.23`. Restrict the lint image to the jsonnet binaries it actually ships so it compiles under the newer toolchain.

- Build only `jsonnet`/`jsonnetfmt`, skipping the C++ wrapper that no longer compiles
- Fix the `2LDFLAGS` → `LDFLAGS` typo so `-static` actually applies, and drop the now statically-linked `libgcc`/`libstdc++`
- Add `.SHELLFLAGS := -ec` to the Makefile so recipes fail fast instead of masking build errors

### Root cause

The lint image compiles jsonnet v0.14.0 from source, and alpine 3.23's GCC rejects that old code — `cpp/libjsonnet++.cpp` uses `uint32_t` without including `<cstdint>`. The break hid as a "build succeeds, publish fails": with `.ONESHELL` recipes running without `set -e`, the failed `docker build` was followed by a successful `touch`, so `make build` returned 0 and left `make publish` to die pushing a `tns-lint` image that was never built.