### PR TITLE
fix: keep TNS images current and pin deploys by digest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
   lint-jsonnet:
     <<: *defaults
     docker:
-      - image: grafana/tns-lint:6daf0b2
+      - image: grafana/tns-lint:ae5c2f3@sha256:0644574a7b32fa53d54ae9a1dc1ecf652ea14418adc188ee4cd631018fc38d3e
     steps:
       - checkout
       - run:

--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,15 @@ lint-image/.uptodate: lint-image/Dockerfile
 
 db/.published: db/.uptodate
 	docker push $(DOCKER_IMAGE_BASE)/tns-db:$(IMAGE_TAG)
+	docker push $(DOCKER_IMAGE_BASE)/tns-db:latest
 
 app/.published: app/.uptodate
 	docker push $(DOCKER_IMAGE_BASE)/tns-app:$(IMAGE_TAG)
+	docker push $(DOCKER_IMAGE_BASE)/tns-app:latest
 
 loadgen/.published: loadgen/.uptodate
 	docker push $(DOCKER_IMAGE_BASE)/tns-loadgen:$(IMAGE_TAG)
+	docker push $(DOCKER_IMAGE_BASE)/tns-loadgen:latest
 
 lint-image/.published: lint-image/.uptodate
 	docker push $(DOCKER_IMAGE_BASE)/tns-lint:$(IMAGE_TAG)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This readme has the following sections:
   - [Contributing guidelines](#contributing-guidelines)
     - [Modify TNS application:](#modify-tns-application)
     - [Update Grafana dashboards and kubernetes infrastructure:](#update-grafana-dashboards-and-kubernetes-infrastructure)
+    - [Releasing changes:](#releasing-changes)
 
 ## Overview
 
@@ -252,6 +253,13 @@ rm -rf tanka
 
 - Update the manifests by running the following tanka command: `tk apply --force environments/<ENV>/main.jsonnet`.
 - Update Grafana, for example, when changing dashboards by running the following tanka command: `tk apply --force environments/default/main.jsonnet`.
+
+### Releasing changes:
+
+The deployed Docker images are pinned by digest, so a code change reaches the demo in two PRs:
+
+1. Open a PR with the desired change and get it merged. On merge to `main`, CI builds and publishes new images tagged with the commit SHA (and updates `:latest`).
+2. Once that merge build completes cleanly, open a second PR that updates the pinned image digests for the four TNS images — `tns-app`, `tns-db`, and `tns-loadgen` in `production/tns/config.libsonnet`, and `tns-lint` in `.circleci/config.yml` — to the digests of the freshly published build.
 
 ## Using TNS for Grafana Development
 

--- a/production/tns/config.libsonnet
+++ b/production/tns/config.libsonnet
@@ -11,8 +11,8 @@
   },
 
   _images+:: {
-    tns_app: 'grafana/tns-app:latest',
-    loadgen: 'grafana/tns-loadgen:latest',
-    db: 'grafana/tns-db:latest',
+    tns_app: 'grafana/tns-app:ae5c2f3@sha256:9891c964d6d76d7504dd72732181e73ad04b774d3b8bb9d558afa809a98c5f65',
+    loadgen: 'grafana/tns-loadgen:ae5c2f3@sha256:ccfcb20a3551349fa7a79dbc7848e75729c4f149b56258e7bd7846451152cf2f',
+    db: 'grafana/tns-db:ae5c2f3@sha256:cf5136b25e6b09024f50681e57e3c11564c1f37c46714ef070f714d9347fa85b',
   },
 }


### PR DESCRIPTION
## Summary

Fix the TNS demo install pulling a stale 2020 image, and make published images reproducible going forward. The deploy config referenced `grafana/tns-*:latest`, but CI only ever pushed commit-SHA tags — so `:latest` had been frozen on a November 2020 build, and a fresh `k3d` install pulled that instead of recent code.

- `make publish` now pushes `:latest` alongside the SHA tag for `tns-app`, `tns-db`, and `tns-loadgen`, so the floating tag tracks the latest `main` build
- Pin all four TNS images to the `ae5c2f3` build by digest — `tns-app`/`tns-db`/`tns-loadgen` in `production/tns/config.libsonnet`, `tns-lint` in `.circleci/config.yml` — for reproducible installs and CI
- Document the two-PR release flow (merge the change, then bump digests once the build is clean) in the contributing guidelines

### Context

Recreating a cluster and running `install` deployed `grafana/tns-app:latest`, which Docker Hub had last updated on 2020-11-05 — CI publishes per-commit SHA tags via `make publish` but never refreshed `:latest`. Pinning the deploy and lint images by digest removes the dependence on a mutable tag, and keeping `:latest` current restores a sane default for the docker-compose and manual paths that still reference it.