### PR TITLE
Fix docker-compose demo for Tempo 3.0 and Prometheus 3.x

### DIFF
--- a/production/docker-compose/docker-compose.yml
+++ b/production/docker-compose/docker-compose.yml
@@ -95,6 +95,7 @@ services:
       - --storage.tsdb.retention.time=1d
       - --enable-feature=exemplar-storage
       - --enable-feature=native-histograms
+      - --web.enable-remote-write-receiver
       - --log.level=debug
       - --web.enable-admin-api
     volumes:

--- a/production/docker-compose/tempo.yaml
+++ b/production/docker-compose/tempo.yaml
@@ -6,10 +6,6 @@ storage:
     local:
       path: /var/tempo/blocks
 
-compactor:
-  compaction:
-    block_retention: 24h
-
 distributor:
   receivers:
     jaeger:
@@ -30,8 +26,6 @@ distributor:
           endpoint: "tempo:4317"
         http:
           endpoint: "tempo:4318"
-    opencensus:
-      endpoint: "tempo:55678"
 
 metrics_generator:
   registry:
@@ -43,15 +37,11 @@ metrics_generator:
     remote_write:
       - url: http://prometheus:9090/api/v1/write
         send_exemplars: true
-  traces_storage:
-    path: /var/tempo/generator/traces
-  processor:
-    local_blocks:
-      filter_server_spans: false
-      flush_to_storage: true
 
 overrides:
   defaults:
+    compaction:
+      block_retention: 24h
     metrics_generator:
-      processors: [service-graphs, span-metrics, local-blocks] # enables metrics generator
+      processors: [service-graphs, span-metrics] # enables metrics generator
       generate_native_histograms: both


### PR DESCRIPTION
The compose stack was broken by image bumps that outran their configs:

- tempo.yaml was written for Tempo 2.x: top-level `compactor` was removed in 3.0 (block_retention now lives in overrides.defaults. compaction), the `opencensus` receiver no longer exists (nothing in TNS sends OpenCensus; all tiers use Jaeger), and the metrics- generator `traces_storage`/`local_blocks` processor moved into the live-store architecture. Tempo crash-looped on startup.

- Prometheus 3.x requires --web.enable-remote-write-receiver for the Tempo metrics-generator remote_write; without it every push 404s and no service-graph/span metrics (or the Grafana service map) work.

Verified: all containers stay up, traces searchable via TraceQL, traces_service_graph_request_total flowing into Prometheus with <15s freshness, exemplars enabled.